### PR TITLE
Add agent instructions, format hook, and Ubuntu format CI

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "hooks": {
+    "afterFileEdit": [
+      {
+        "command": ".cursor/hooks/format.sh"
+      }
+    ]
+  }
+}

--- a/.cursor/hooks/format.sh
+++ b/.cursor/hooks/format.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Format Swift files with swift-format after an agent file edit.
+
+PATH="/usr/bin:/bin:/opt/homebrew/bin:/usr/local/bin:${PATH:-}"
+
+input=$(cat)
+file_path=$(
+  printf '%s\n' "$input" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("file_path") or "")' 2>/dev/null
+) || exit 0
+
+[[ -n "$file_path" ]] || exit 0
+[[ "$file_path" == /* ]] || file_path="$PWD/$file_path"
+[[ -f "$file_path" ]] || exit 0
+[[ "$file_path" == *.swift ]] || exit 0
+
+config="${PWD}/.swift-format"
+if [[ -f "$config" ]]; then
+  swift format --in-place --configuration "$config" "$file_path" || true
+else
+  swift format --in-place "$file_path" || true
+fi
+
+exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,25 @@ name: CI
 on: push
 
 jobs:
+  format:
+    name: format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Swift
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "6.1"
+      - name: Lint
+        run: >
+          swift format lint
+          --strict
+          --parallel
+          --recursive
+          --configuration .swift-format
+          Sources Tests Package.swift
+
   test:
     runs-on: macos-latest
     strategy:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Qualtive Swift Client
+
+SPM library for posting feedback to [qualtive.io](https://qualtive.io).
+
+## Validations
+
+Always validate changes by running `swift build` and `swift test`.
+
+## Conventions
+
+- Note user-facing changes in `CHANGELOG.md` under Unreleased.


### PR DESCRIPTION
## Summary
- Add a short `AGENTS.md` so agents know how to validate changes and keep the changelog up to date.
- Format Swift files in place after agent edits using the repo `.swift-format` config.
- Fail CI on Ubuntu when `Sources`, `Tests`, or `Package.swift` drift from that config (`swift format lint --strict`).

## Test plan
- [x] `swift format lint --strict --parallel --recursive --configuration .swift-format Sources Tests Package.swift` exits 0 locally
- [ ] GitHub Actions `format` job on `ubuntu-latest` passes
- [x] After an agent edit to a Swift file, `.cursor/hooks/format.sh` rewrites it to match `.swift-format`