### PR TITLE
Adopt Swift 6.0 tools and remaining Sendable types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Dropped CocoaPods support. Swift Package Manager is the only supported installation method. 1.5.0 remains the last CocoaPods release.
+- Upgraded to Swift 6.0 tools.
 - Raised minimum platforms to iOS 15, iPadOS 15, macOS 12, tvOS 15, and watchOS 8.
 - Networking APIs are async-only. Completion-handler variants of `Entry.post`, `Question.fetch`, and `Attachment.create` were removed.
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 
 import PackageDescription
 

--- a/Sources/Qualtive/Attributes.swift
+++ b/Sources/Qualtive/Attributes.swift
@@ -8,7 +8,7 @@ struct Attributes {
 
   private init() {}
 
-  static func defaultAttributes(locale: Locale) -> [String: String] {
+  static func defaultAttributes(locale: Locale) async -> [String: String] {
     var attributes: [String: String] = [:]
 
     if let attribute = platform() { attributes["Platform"] = attribute }
@@ -17,7 +17,7 @@ struct Attributes {
     if let attribute = osVersion() { attributes["OS Version"] = attribute }
 
     if let attribute = deviceModel() { attributes["Device Model"] = attribute }
-    if let attribute = deviceType() { attributes["Device Type"] = attribute }
+    if let attribute = await deviceType() { attributes["Device Type"] = attribute }
 
     if let attribute = appIdentifier() { attributes["App ID"] = attribute }
     if let attribute = appVersion() { attributes["App Version"] = attribute }
@@ -71,7 +71,8 @@ struct Attributes {
       }
       var model = [CChar](repeating: 0, count: count)
       sysctlbyname("hw.model", &model, &count, nil, 0)
-      return String(cString: model)
+      let utf8 = model.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }
+      return String(decoding: utf8, as: UTF8.self)
     }
 
     func systemInfo() -> String? {
@@ -94,9 +95,9 @@ struct Attributes {
       return systemInfo()
     #endif
   }
-  private static func deviceType() -> String? {
+  private static func deviceType() async -> String? {
     #if os(iOS)
-      switch UIDevice.current.userInterfaceIdiom {
+      switch await UIDevice.current.userInterfaceIdiom {
       case .phone:
         return "Phone"
       case .pad:
@@ -107,6 +108,8 @@ struct Attributes {
         return "TV"
       case .carPlay:
         return "Car"
+      case .vision:
+        return "Vision"
       case .unspecified:
         return nil
       @unknown default:

--- a/Sources/Qualtive/Entry+Content.swift
+++ b/Sources/Qualtive/Entry+Content.swift
@@ -10,7 +10,7 @@ extension Entry {
   /// - `text`: Free-form text input. User can type whatever text he/she wants.
   /// - `select`: Single select/radio button input. User can select one of many possible pre-defined options.
   /// - `multiselect`: Multi-select/checkbox buttons input. User can select on or many of possible pre-defined options.
-  public enum Content {
+  public enum Content: Sendable {
 
     /// Static title that was displayed to the user. Is not user interactable.
     case title(TitleContent)
@@ -32,7 +32,7 @@ extension Entry {
   }
 
   /// Static title that was displayed to the user. Not user interactable.
-  public struct TitleContent {
+  public struct TitleContent: Sendable {
 
     /// Source definition of the content from the question.
     public let definition: Question.TitleContent
@@ -56,7 +56,7 @@ extension Entry {
   }
 
   /// Score/rating input for a single value between 0 and 100.
-  public struct ScoreContent {
+  public struct ScoreContent: Sendable {
 
     /// Source definition of the content from the question.
     public let definition: Question.ScoreContent
@@ -83,7 +83,7 @@ extension Entry {
   }
 
   /// Free-form text input. User can type whatever text he/she wants.
-  public struct TextContent {
+  public struct TextContent: Sendable {
 
     /// Source definition of the content from the question.
     public let definition: Question.TextContent
@@ -107,7 +107,7 @@ extension Entry {
   }
 
   /// Single select/radio button input. User can select one of many possible pre-defined options.
-  public struct SelectContent {
+  public struct SelectContent: Sendable {
 
     /// Source definition of the content from the question.
     public let definition: Question.SelectContent
@@ -131,7 +131,7 @@ extension Entry {
   }
 
   /// Multi-select/checkbox buttons input. User can select on or many of possible pre-defined options.
-  public struct MultiselectContent {
+  public struct MultiselectContent: Sendable {
 
     /// Source definition of the content from the question.
     public let definition: Question.MultiselectContent
@@ -155,7 +155,7 @@ extension Entry {
   }
 
   /// Attachments/files input.
-  public struct AttachmentsContent {
+  public struct AttachmentsContent: Sendable {
 
     /// Source definition of the content from the question.
     public let definition: Question.AttachmentsContent

--- a/Sources/Qualtive/Entry.swift
+++ b/Sources/Qualtive/Entry.swift
@@ -107,7 +107,7 @@ public struct Entry: Sendable {
     }
 
     do {
-      var attributes = Attributes.defaultAttributes(locale: locale)
+      var attributes = await Attributes.defaultAttributes(locale: locale)
       for (key, value) in customAttributes {
         attributes[key] = value
       }

--- a/Sources/Qualtive/Error.swift
+++ b/Sources/Qualtive/Error.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-struct ParseError: Error {
+struct ParseError: Error, Sendable {
 
   let debugMessage: String
 }
 
-enum UnexpectedError: Error {
+enum UnexpectedError: Error, Sendable {
   case remoteMaintenance
   case httpStatusCode(Int)
 }

--- a/Sources/Qualtive/PrivateOptions.swift
+++ b/Sources/Qualtive/PrivateOptions.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct PrivateOptions {
+struct PrivateOptions: Sendable {
 
   let _remoteURLString: String?
 }


### PR DESCRIPTION
## Summary
- Bump the package to Swift 6.0 tools (Swift 6 language mode).
- Collect device type by awaiting `UIDevice` instead of isolating attribute collection, and cover the vision idiom plus the `hw.model` string conversion.
- Add `Sendable` on entry content types and the remaining internal value types. Public network errors still wrap existential `Error` and cannot conform.

## Test plan
- [ ] `swift build` on macOS with Swift 6
- [ ] iOS simulator build with `SWIFT_STRICT_CONCURRENCY=complete` (confirms no `UIDevice` isolation warnings)
- [ ] Existing tests still compile/pass for macOS and iOS