### PR TITLE
Parse full Enquiry model and content types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,5 +57,4 @@ jobs:
           -scheme Qualtive
           -destination '${{ matrix.destination }}'
           -derivedDataPath .derivedData
-          -quiet
           COMPILER_INDEX_STORE_ENABLE=NO

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- Full enquiry fetch model: `theme`, `container`, `submittedPages` (with score conditions), and `isUserContactDetailsRequired`.
+- Page content types `body`, `image`, and `contactDetails`; select `allowsCustomInput`; text `storageTarget`; and score `stars5`.
+- Optional `previewToken` on `EnquiryController.fetch` for unpublished drafts.
+
 ### Changed
 
 - Dropped CocoaPods support. Swift Package Manager is the only supported installation method. 1.5.0 remains the last CocoaPods release.

--- a/Sources/Qualtive/Controllers/EnquiryController.swift
+++ b/Sources/Qualtive/Controllers/EnquiryController.swift
@@ -8,18 +8,28 @@ public protocol EnquiryControllerType: Sendable {
   ///   - collection: The collection identifier for the enquiry.
   ///   - locale: The locale to use. If the enquiry is translated on Qualtive this specifies
   ///     which translation to use for localizable fields. Defaults to device locale.
+  ///   - previewToken: Optional preview token for unpublished enquiry drafts.
   /// - Returns: Enquiry definition.
   /// - Throws: `FetchError`, or `CancellationError` when cancelled.
   func fetch(
     collection: Collection,
-    locale: Locale
+    locale: Locale,
+    previewToken: String?
   ) async throws -> Enquiry
 }
 
 extension EnquiryControllerType {
 
   public func fetch(collection: Collection) async throws -> Enquiry {
-    try await fetch(collection: collection, locale: .current)
+    try await fetch(collection: collection, locale: .current, previewToken: nil)
+  }
+
+  public func fetch(collection: Collection, locale: Locale) async throws -> Enquiry {
+    try await fetch(collection: collection, locale: locale, previewToken: nil)
+  }
+
+  public func fetch(collection: Collection, previewToken: String?) async throws -> Enquiry {
+    try await fetch(collection: collection, locale: .current, previewToken: previewToken)
   }
 }
 
@@ -43,12 +53,13 @@ public struct EnquiryController: EnquiryControllerType {
 
   public func fetch(
     collection: Collection,
-    locale: Locale
+    locale: Locale,
+    previewToken: String?
   ) async throws -> Enquiry {
     do {
       return try await networkController.send(
         method: "GET",
-        path: "/feedback/enquiries/\(collection.enquiryId)/",
+        path: enquiryPath(enquiryId: collection.enquiryId, previewToken: previewToken),
         containerId: collection.containerId.rawValue,
         headers: [
           "Accept-Language": locale.identifier.replacingOccurrences(of: "_", with: "-")
@@ -58,6 +69,18 @@ public struct EnquiryController: EnquiryControllerType {
       throw mapFetchError(error)
     }
   }
+}
+
+private func enquiryPath(enquiryId: EnquiryId, previewToken: String?) -> String {
+  var path = "/feedback/enquiries/\(enquiryId)/"
+  if let previewToken, !previewToken.isEmpty {
+    var components = URLComponents()
+    components.queryItems = [URLQueryItem(name: "previewToken", value: previewToken)]
+    if let query = components.percentEncodedQuery {
+      path += "?\(query)"
+    }
+  }
+  return path
 }
 
 private func mapFetchError(_ error: NetworkError) -> EnquiryController.FetchError {

--- a/Sources/Qualtive/Models/Enquiry+Container.swift
+++ b/Sources/Qualtive/Models/Enquiry+Container.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+extension Enquiry {
+
+  /// Container (workspace) details for an enquiry.
+  public struct Container: Sendable, Decodable {
+
+    /// Identifier of the container.
+    public let id: String
+
+    /// `true` if the container may hide Qualtive branding.
+    public let isWhiteLabel: Bool
+
+    /// Custom logos for the container.
+    public let customLogos: [CustomLogo]
+
+    /// Visibility mode of responses.
+    public let visibilityMode: VisibilityMode
+
+    private enum CodingKeys: String, CodingKey {
+      case id
+      case isWhiteLabel
+      case customLogos
+      case visibilityMode
+    }
+
+    public init(
+      id: String,
+      isWhiteLabel: Bool = false,
+      customLogos: [CustomLogo] = [],
+      visibilityMode: VisibilityMode
+    ) {
+      self.id = id
+      self.isWhiteLabel = isWhiteLabel
+      self.customLogos = customLogos
+      self.visibilityMode = visibilityMode
+    }
+
+    public init(from decoder: Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      let loggingController =
+        (decoder.userInfo[CodingUserInfoKey.loggingController] as? any LoggingControllerType)
+        ?? LoggingController()
+
+      self.id = try container.decode(String.self, forKey: .id)
+      self.isWhiteLabel = try container.decodeIfPresent(Bool.self, forKey: .isWhiteLabel) ?? false
+
+      self.customLogos = try container.decodeSkippingUnknownIfPresent(
+        [CustomLogo].self,
+        forKey: .customLogos
+      )
+
+      let visibilityRaw = try container.decode(String.self, forKey: .visibilityMode)
+      switch visibilityRaw {
+      case "public":
+        self.visibilityMode = .public
+      case "private":
+        self.visibilityMode = .private
+      default:
+        loggingController.logHintNewVersion()
+        self.visibilityMode = .private
+      }
+    }
+
+    /// Custom logo variant for a container.
+    public struct CustomLogo: Sendable, Equatable, Decodable {
+      public let size: Size
+      public let intendedBackground: IntendedBackground
+      public let primaryColor: String
+      public let urlVector: String
+
+      public init(
+        size: Size,
+        intendedBackground: IntendedBackground,
+        primaryColor: String,
+        urlVector: String
+      ) {
+        self.size = size
+        self.intendedBackground = intendedBackground
+        self.primaryColor = primaryColor
+        self.urlVector = urlVector
+      }
+
+      public enum Size: Sendable, Equatable {
+        case wide
+        case square
+      }
+
+      public enum IntendedBackground: Sendable, Equatable {
+        case light
+        case dark
+      }
+
+      private enum CodingKeys: String, CodingKey {
+        case size
+        case intendedBackground
+        case primaryColor
+        case urlVector
+      }
+
+      public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let sizeRaw = try container.decode(String.self, forKey: .size)
+        let backgroundRaw = try container.decode(String.self, forKey: .intendedBackground)
+
+        let size: Size?
+        switch sizeRaw {
+        case "wide": size = .wide
+        case "square": size = .square
+        default: size = nil
+        }
+
+        let intendedBackground: IntendedBackground?
+        switch backgroundRaw {
+        case "light": intendedBackground = .light
+        case "dark": intendedBackground = .dark
+        default: intendedBackground = nil
+        }
+
+        guard let size, let intendedBackground else {
+          try throwUnknownAPIValue(decoder)
+        }
+
+        self.init(
+          size: size,
+          intendedBackground: intendedBackground,
+          primaryColor: try container.decode(String.self, forKey: .primaryColor),
+          urlVector: try container.decode(String.self, forKey: .urlVector)
+        )
+      }
+    }
+
+    /// Visibility mode of the container.
+    public enum VisibilityMode: Sendable, Equatable {
+      case `public`
+      case `private`
+    }
+  }
+}

--- a/Sources/Qualtive/Models/Enquiry+Content.swift
+++ b/Sources/Qualtive/Models/Enquiry+Content.swift
@@ -6,15 +6,24 @@ extension Enquiry {
   ///
   /// Possible content kinds:
   /// - `title`: Static title to display to the user. Not user interactable.
+  /// - `body`: Static body text to display to the user. Not user interactable.
+  /// - `image`: Static image to display to the user. Not user interactable.
   /// - `score`: Score/rating input for a single value between 0 and 100.
   /// - `text`: Free-form text input. User can type whatever text he/she wants.
   /// - `select`: Single select/radio button input. User can select one of many possible pre-defined options.
   /// - `multiselect`: Multi-select/checkbox buttons input. User can select on or many of possible pre-defined options.
   /// - `attachments`: Attachments/files input.
-  public enum Content: Sendable {
+  /// - `contactDetails`: Contact details input if not given automatically.
+  public enum Content: Sendable, Decodable {
 
     /// Static title to display to the user. Not user interactable.
     case title(TitleContent)
+
+    /// Static body text to display to the user. Not user interactable.
+    case body(BodyContent)
+
+    /// Static image to display to the user. Not user interactable.
+    case image(ImageContent)
 
     /// Score/rating input for a single value between 0 and 100.
     case score(ScoreContent)
@@ -30,6 +39,9 @@ extension Enquiry {
 
     /// Attachments/files input.
     case attachments(AttachmentsContent)
+
+    /// Contact details input if not given automatically.
+    case contactDetails(ContactDetailsContent)
   }
 
   /// Static title to display to the user. Not user interactable.
@@ -40,6 +52,28 @@ extension Enquiry {
 
     public init(text: String = "") {
       self.text = text
+    }
+  }
+
+  /// Static body text to display to the user. Not user interactable.
+  public struct BodyContent: Sendable, Decodable {
+
+    /// Text of the body to display.
+    public let text: String
+
+    public init(text: String = "") {
+      self.text = text
+    }
+  }
+
+  /// Static image to display to the user. Not user interactable.
+  public struct ImageContent: Sendable, Decodable {
+
+    /// Remote image attachment.
+    public let attachment: ContentAttachment
+
+    public init(attachment: ContentAttachment) {
+      self.attachment = attachment
     }
   }
 
@@ -60,8 +94,47 @@ extension Enquiry {
     /// Placeholder to display in the text input.
     public let placeholder: String?
 
-    public init(placeholder: String? = nil) {
+    /// Where the text input is stored when posting.
+    public let storageTarget: StorageTarget
+
+    public init(
+      placeholder: String? = nil,
+      storageTarget: StorageTarget = .text
+    ) {
       self.placeholder = placeholder
+      self.storageTarget = storageTarget
+    }
+
+    /// Where text input is stored when posting.
+    public enum StorageTarget: Sendable, Equatable, Decodable {
+
+      /// Stored as entry text content.
+      case text
+
+      /// Stored as a custom attribute.
+      case attribute(String)
+
+      private enum CodingKeys: String, CodingKey {
+        case type
+        case attribute
+      }
+
+      public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+        switch type {
+        case "text":
+          self = .text
+        case "attribute":
+          self = .attribute(try container.decode(String.self, forKey: .attribute))
+        default:
+          throw DecodingError.dataCorruptedError(
+            forKey: .type,
+            in: container,
+            debugDescription: "Unknown storageTarget type: \(type)"
+          )
+        }
+      }
     }
   }
 
@@ -71,8 +144,12 @@ extension Enquiry {
     /// Possible options to select.
     public let options: [String]
 
-    public init(options: [String] = []) {
+    /// When `true`, the user may enter a custom value instead of a predefined option.
+    public let allowsCustomInput: Bool
+
+    public init(options: [String] = [], allowsCustomInput: Bool = false) {
       self.options = options
+      self.allowsCustomInput = allowsCustomInput
     }
   }
 
@@ -92,12 +169,37 @@ extension Enquiry {
 
     public init() {}
   }
+
+  /// Contact details input if not given automatically.
+  public struct ContactDetailsContent: Sendable, Decodable {
+
+    /// Title shown above the contact details field.
+    public let title: String
+
+    /// Placeholder shown in the contact details field.
+    public let placeholder: String?
+
+    public init(title: String = "", placeholder: String? = nil) {
+      self.title = title
+      self.placeholder = placeholder
+    }
+  }
+
+  /// Remote attachment referenced by enquiry content.
+  public struct ContentAttachment: Sendable, Decodable, Equatable {
+
+    /// Remote URL to the attachment.
+    public let url: String
+
+    public init(url: String) {
+      self.url = url
+    }
+  }
 }
 
-/// Decodes a single content object, returning `nil` for unknown or unsupported types.
-struct ContentBox: Decodable {
+extension Enquiry.Content {
 
-  enum CodingKeys: String, CodingKey {
+  fileprivate enum CodingKeys: String, CodingKey {
     case type
     case text
     case scoreType
@@ -105,52 +207,62 @@ struct ContentBox: Decodable {
     case trailingText
     case placeholder
     case options
+    case allowsCustomInput
+    case storageTarget
+    case attachment
+    case title
   }
 
-  let value: Enquiry.Content?
-
-  init(from decoder: Decoder) throws {
-    let loggingController =
-      (decoder.userInfo[CodingUserInfoKey.loggingController] as? any LoggingControllerType)
-      ?? LoggingController()
+  public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let type = try container.decode(String.self, forKey: .type)
 
     switch type {
     case "title":
       let text = try container.decode(String.self, forKey: .text)
-      value = .title(.init(text: text))
+      self = .title(.init(text: text))
+    case "body":
+      let text = try container.decode(String.self, forKey: .text)
+      self = .body(.init(text: text))
+    case "image":
+      let attachment = try container.decode(Enquiry.ContentAttachment.self, forKey: .attachment)
+      self = .image(.init(attachment: attachment))
     case "score":
-      guard let kind = try Score.Kind(from: container, loggingController: loggingController)
-      else {
-        value = nil
-        return
+      guard let kind = try Score.Kind(from: container) else {
+        try throwUnknownAPIValue(decoder)
       }
-      value = .score(.init(kind: kind))
+      self = .score(.init(kind: kind))
     case "text":
       let placeholder = try container.decodeIfPresent(String.self, forKey: .placeholder)
-      value = .text(.init(placeholder: placeholder))
+      let storageTarget =
+        try container.decodeIfPresent(
+          Enquiry.TextContent.StorageTarget.self,
+          forKey: .storageTarget
+        ) ?? .text
+      self = .text(.init(placeholder: placeholder, storageTarget: storageTarget))
     case "select":
       let options = try container.decode([String].self, forKey: .options)
-      value = .select(.init(options: options))
+      let allowsCustomInput =
+        try container.decodeIfPresent(Bool.self, forKey: .allowsCustomInput) ?? false
+      self = .select(.init(options: options, allowsCustomInput: allowsCustomInput))
     case "multiselect":
       let options = try container.decode([String].self, forKey: .options)
-      value = .multiselect(.init(options: options))
+      self = .multiselect(.init(options: options))
     case "attachments":
-      value = .attachments(.init())
+      self = .attachments(.init())
+    case "contactDetails":
+      let title = try container.decode(String.self, forKey: .title)
+      let placeholder = try container.decodeIfPresent(String.self, forKey: .placeholder)
+      self = .contactDetails(.init(title: title, placeholder: placeholder))
     default:
-      loggingController.logHintNewVersion()
-      value = nil
+      try throwUnknownAPIValue(decoder)
     }
   }
 }
 
 extension Score.Kind {
 
-  fileprivate init?(
-    from container: KeyedDecodingContainer<ContentBox.CodingKeys>,
-    loggingController: any LoggingControllerType
-  ) throws {
+  fileprivate init?(from container: KeyedDecodingContainer<Enquiry.Content.CodingKeys>) throws {
     let type = try container.decode(String.self, forKey: .scoreType)
     switch type {
     case "smilies5":
@@ -164,8 +276,9 @@ extension Score.Kind {
         leadingText: try container.decodeIfPresent(String.self, forKey: .leadingText) ?? "",
         trailingText: try container.decodeIfPresent(String.self, forKey: .trailingText) ?? ""
       )
+    case "stars5":
+      self = .stars5
     default:
-      loggingController.logHintNewVersion()
       return nil
     }
   }

--- a/Sources/Qualtive/Models/Enquiry+SubmittedPage.swift
+++ b/Sources/Qualtive/Models/Enquiry+SubmittedPage.swift
@@ -1,0 +1,206 @@
+import Foundation
+
+extension Enquiry {
+
+  /// Thank-you / submitted page, optionally gated by score conditions.
+  public struct SubmittedPage: Sendable, Decodable {
+
+    /// Content shown on the submitted page.
+    public let content: [Content]
+
+    /// Conditions that must match for this submitted page to be shown.
+    public let conditions: [Condition]
+
+    private enum CodingKeys: String, CodingKey {
+      case content
+      case conditions
+    }
+
+    public init(content: [Content], conditions: [Condition] = []) {
+      self.content = content
+      self.conditions = conditions
+    }
+
+    public init(from decoder: Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      self.content = try container.decodeSkippingUnknownIfPresent(
+        [Content].self,
+        forKey: .content
+      )
+      self.conditions = try container.decodeSkippingUnknownIfPresent(
+        [Condition].self,
+        forKey: .conditions
+      )
+    }
+
+    /// Content block on a submitted page.
+    public enum Content: Sendable, Decodable {
+      case title(Title)
+      case body(Body)
+      case image(Image)
+      case confirmationText(ConfirmationText)
+      case name
+      case userInput
+      case userInputScore
+      case link(Link)
+      case reviewLinks(ReviewLinks)
+
+      public struct Title: Sendable, Equatable {
+        public let text: String
+        public init(text: String) { self.text = text }
+      }
+
+      public struct Body: Sendable, Equatable {
+        public let text: String
+        public init(text: String) { self.text = text }
+      }
+
+      public struct Image: Sendable, Equatable {
+        public let attachment: ContentAttachment
+        public let linkURL: String?
+        public init(attachment: ContentAttachment, linkURL: String? = nil) {
+          self.attachment = attachment
+          self.linkURL = linkURL
+        }
+      }
+
+      public struct ConfirmationText: Sendable, Equatable {
+        public let text: String
+        public init(text: String) { self.text = text }
+      }
+
+      public struct Link: Sendable, Equatable {
+        public let text: String
+        public let url: String
+        public init(text: String, url: String) {
+          self.text = text
+          self.url = url
+        }
+      }
+
+      public struct ReviewLinks: Sendable, Equatable {
+        public let links: [Link]
+        public init(links: [Link]) { self.links = links }
+
+        public struct Link: Sendable, Equatable, Decodable {
+          public let title: String
+          public let url: String
+          public let logo: Logo?
+          public let icon: Icon?
+
+          public init(title: String, url: String, logo: Logo? = nil, icon: Icon? = nil) {
+            self.title = title
+            self.url = url
+            self.logo = logo
+            self.icon = icon
+          }
+
+          public struct Logo: Sendable, Equatable, Decodable {
+            public let urlVector: String
+            public let urlVectorDark: String
+            public init(urlVector: String, urlVectorDark: String) {
+              self.urlVector = urlVector
+              self.urlVectorDark = urlVectorDark
+            }
+          }
+
+          public struct Icon: Sendable, Equatable, Decodable {
+            public let urlRaster: String
+            public let urlRasterDark: String
+            public init(urlRaster: String, urlRasterDark: String) {
+              self.urlRaster = urlRaster
+              self.urlRasterDark = urlRasterDark
+            }
+          }
+        }
+      }
+
+      private enum CodingKeys: String, CodingKey {
+        case type
+        case text
+        case attachment
+        case linkURL
+        case url
+        case links
+      }
+
+      public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+
+        switch type {
+        case "title":
+          self = .title(.init(text: try container.decode(String.self, forKey: .text)))
+        case "body":
+          self = .body(.init(text: try container.decode(String.self, forKey: .text)))
+        case "image":
+          self = .image(
+            .init(
+              attachment: try container.decode(ContentAttachment.self, forKey: .attachment),
+              linkURL: try container.decodeIfPresent(String.self, forKey: .linkURL)
+            )
+          )
+        case "confirmationText":
+          self = .confirmationText(.init(text: try container.decode(String.self, forKey: .text)))
+        case "name":
+          self = .name
+        case "userInput":
+          self = .userInput
+        case "userInputScore":
+          self = .userInputScore
+        case "link":
+          self = .link(
+            .init(
+              text: try container.decode(String.self, forKey: .text),
+              url: try container.decode(String.self, forKey: .url)
+            )
+          )
+        case "reviewLinks":
+          self = .reviewLinks(
+            .init(links: try container.decode([ReviewLinks.Link].self, forKey: .links))
+          )
+        default:
+          try throwUnknownAPIValue(decoder)
+        }
+      }
+    }
+
+    /// Condition that must match for this submitted page to be shown.
+    public enum Condition: Sendable, Decodable {
+      case score(Score)
+
+      public struct Score: Sendable, Equatable {
+        public let ranges: [Range]
+        public init(ranges: [Range]) { self.ranges = ranges }
+
+        public struct Range: Sendable, Equatable, Decodable {
+          public let lower: Int?
+          public let upper: Int?
+          public init(lower: Int?, upper: Int?) {
+            self.lower = lower
+            self.upper = upper
+          }
+        }
+      }
+
+      private enum CodingKeys: String, CodingKey {
+        case type
+        case ranges
+      }
+
+      public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+
+        switch type {
+        case "score":
+          self = .score(
+            .init(ranges: try container.decode([Score.Range].self, forKey: .ranges))
+          )
+        default:
+          try throwUnknownAPIValue(decoder)
+        }
+      }
+    }
+  }
+}

--- a/Sources/Qualtive/Models/Enquiry+Theme.swift
+++ b/Sources/Qualtive/Models/Enquiry+Theme.swift
@@ -1,0 +1,206 @@
+import Foundation
+
+extension Enquiry {
+
+  /// Visual theme for an enquiry.
+  public struct Theme: Sendable, Decodable {
+
+    /// Background configuration for the enquiry form.
+    public let background: Background
+
+    /// Font configuration for the enquiry form.
+    public let font: Font
+
+    /// Corner style of UI elements in the form.
+    public let cornerStyle: CornerStyle
+
+    /// Whether the background attachment is visible in public responses.
+    public let isBackgroundAttachmentVisibleInResponses: Bool
+
+    /// Whether the background color is visible in public responses.
+    public let isBackgroundColorVisibleInResponses: Bool
+
+    private enum CodingKeys: String, CodingKey {
+      case background
+      case font
+      case cornerStyle
+      case isBackgroundAttachmentVisibleInResponses
+      case isBackgroundColorVisibleInResponses
+    }
+
+    public init(
+      background: Background,
+      font: Font,
+      cornerStyle: CornerStyle,
+      isBackgroundAttachmentVisibleInResponses: Bool = true,
+      isBackgroundColorVisibleInResponses: Bool = true
+    ) {
+      self.background = background
+      self.font = font
+      self.cornerStyle = cornerStyle
+      self.isBackgroundAttachmentVisibleInResponses = isBackgroundAttachmentVisibleInResponses
+      self.isBackgroundColorVisibleInResponses = isBackgroundColorVisibleInResponses
+    }
+
+    public init(from decoder: Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      let loggingController =
+        (decoder.userInfo[CodingUserInfoKey.loggingController] as? any LoggingControllerType)
+        ?? LoggingController()
+
+      self.background = try container.decode(Background.self, forKey: .background)
+      self.font = try container.decode(Font.self, forKey: .font)
+
+      let cornerStyleRaw = try container.decode(String.self, forKey: .cornerStyle)
+      switch cornerStyleRaw {
+      case "rounded":
+        self.cornerStyle = .rounded
+      case "square":
+        self.cornerStyle = .square
+      default:
+        loggingController.logHintNewVersion()
+        self.cornerStyle = .rounded
+      }
+
+      self.isBackgroundAttachmentVisibleInResponses =
+        try container.decodeIfPresent(
+          Bool.self,
+          forKey: .isBackgroundAttachmentVisibleInResponses
+        ) ?? true
+      self.isBackgroundColorVisibleInResponses =
+        try container.decodeIfPresent(
+          Bool.self,
+          forKey: .isBackgroundColorVisibleInResponses
+        ) ?? true
+    }
+
+    /// Background configuration for an enquiry theme.
+    public enum Background: Sendable, Decodable {
+
+      /// Predefined background using a built-in style.
+      case predefined(Predefined)
+
+      /// Custom background with optional image and color.
+      case custom(Custom)
+
+      private enum CodingKeys: String, CodingKey {
+        case type
+        case value
+        case attachment
+        case color
+      }
+
+      public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let loggingController =
+          (decoder.userInfo[CodingUserInfoKey.loggingController] as? any LoggingControllerType)
+          ?? LoggingController()
+        let type = try container.decode(String.self, forKey: .type)
+
+        switch type {
+        case "predefined":
+          let valueRaw = try container.decode(String.self, forKey: .value)
+          switch valueRaw {
+          case "plain":
+            self = .predefined(.plain)
+          case "sponda":
+            self = .predefined(.sponda)
+          default:
+            loggingController.logHintNewVersion()
+            self = .predefined(.plain)
+          }
+        case "custom":
+          let attachment = try container.decodeIfPresent(
+            Custom.Attachment.self,
+            forKey: .attachment
+          )
+          let color = try container.decode(Custom.Color.self, forKey: .color)
+          self = .custom(.init(attachment: attachment, color: color))
+        default:
+          throw DecodingError.dataCorruptedError(
+            forKey: .type,
+            in: container,
+            debugDescription: "Unknown background type: \(type)"
+          )
+        }
+      }
+
+      /// Predefined background styles.
+      public enum Predefined: Sendable, Equatable {
+        case plain
+        case sponda
+      }
+
+      /// Custom background configuration.
+      public struct Custom: Sendable, Equatable {
+
+        public let attachment: Attachment?
+        public let color: Color
+
+        public init(attachment: Attachment?, color: Color) {
+          self.attachment = attachment
+          self.color = color
+        }
+
+        public struct Attachment: Sendable, Equatable, Decodable {
+          public let id: Int64
+          public let contentType: String
+          public let url: String
+
+          public init(id: Int64, contentType: String, url: String) {
+            self.id = id
+            self.contentType = contentType
+            self.url = url
+          }
+        }
+
+        public struct Color: Sendable, Equatable, Decodable {
+          public let value: String
+
+          public init(value: String) {
+            self.value = value
+          }
+        }
+      }
+    }
+
+    /// Font configuration for an enquiry theme.
+    public enum Font: Sendable, Decodable {
+
+      /// Predefined font family name (e.g. `"default"`, `"heptaSlab"`).
+      case predefined(String)
+
+      /// Custom font loaded from a remote URL.
+      case custom(url: String)
+
+      private enum CodingKeys: String, CodingKey {
+        case type
+        case value
+        case url
+      }
+
+      public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+        switch type {
+        case "predefined":
+          self = .predefined(try container.decode(String.self, forKey: .value))
+        case "custom":
+          self = .custom(url: try container.decode(String.self, forKey: .url))
+        default:
+          throw DecodingError.dataCorruptedError(
+            forKey: .type,
+            in: container,
+            debugDescription: "Unknown font type: \(type)"
+          )
+        }
+      }
+    }
+
+    /// Corner style of UI elements.
+    public enum CornerStyle: Sendable, Equatable {
+      case rounded
+      case square
+    }
+  }
+}

--- a/Sources/Qualtive/Models/Enquiry.swift
+++ b/Sources/Qualtive/Models/Enquiry.swift
@@ -15,22 +15,79 @@ public struct Enquiry: Sendable, Decodable {
   /// Pages and content structure of the enquiry.
   public let pages: [Page]
 
+  /// Thank-you / submitted pages, optionally gated by score conditions.
+  public let submittedPages: [SubmittedPage]
+
+  /// Theme of the enquiry. Controls appearance properties.
+  public let theme: Theme
+
+  /// Details about the container the enquiry belongs to.
+  public let container: Container
+
+  /// `true` if the user must provide contact details before submitting.
+  public let isUserContactDetailsRequired: Bool
+
+  private enum CodingKeys: String, CodingKey {
+    case id
+    case slug
+    case name
+    case pages
+    case submittedPages
+    case theme
+    case container
+    case isUserContactDetailsRequired
+  }
+
+  public init(
+    id: Int64,
+    slug: String,
+    name: String,
+    pages: [Page],
+    submittedPages: [SubmittedPage] = [],
+    theme: Theme,
+    container: Container,
+    isUserContactDetailsRequired: Bool = false
+  ) {
+    self.id = id
+    self.slug = slug
+    self.name = name
+    self.pages = pages
+    self.submittedPages = submittedPages
+    self.theme = theme
+    self.container = container
+    self.isUserContactDetailsRequired = isUserContactDetailsRequired
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.id = try container.decode(Int64.self, forKey: .id)
+    self.slug = try container.decode(String.self, forKey: .slug)
+    self.name = try container.decode(String.self, forKey: .name)
+    self.pages = try container.decode([Page].self, forKey: .pages)
+    self.submittedPages =
+      try container.decodeIfPresent([SubmittedPage].self, forKey: .submittedPages) ?? []
+    self.theme = try container.decode(Theme.self, forKey: .theme)
+    self.container = try container.decode(Container.self, forKey: .container)
+    self.isUserContactDetailsRequired =
+      try container.decodeIfPresent(Bool.self, forKey: .isUserContactDetailsRequired) ?? false
+  }
+
   /// Creates a default/empty array of entry content; ready to be filled out by the user.
   ///
-  /// Flattens all pages into a single content array. It is safe to assume the length of
-  /// the returned array equals the total number of mapped content items across pages.
+  /// Flattens all pages into a single content array. Static page content that is not part
+  /// of an entry (`body`, `image`, `contactDetails`) is omitted.
   public func entryContentTemplate() -> [Entry.Content] {
     pages.flatMap { page in
-      page.content.map { content in
+      page.content.compactMap { content -> Entry.Content? in
         switch content {
-        case .title(let content): return Entry.Content.title(.init(enquiryContent: content))
-        case .score(let content): return Entry.Content.score(.init(enquiryContent: content))
-        case .text(let content): return Entry.Content.text(.init(enquiryContent: content))
-        case .select(let content): return Entry.Content.select(.init(enquiryContent: content))
-        case .multiselect(let content):
-          return Entry.Content.multiselect(.init(enquiryContent: content))
-        case .attachments(let content):
-          return Entry.Content.attachments(.init(enquiryContent: content))
+        case .title(let content): return .title(.init(enquiryContent: content))
+        case .score(let content): return .score(.init(enquiryContent: content))
+        case .text(let content): return .text(.init(enquiryContent: content))
+        case .select(let content): return .select(.init(enquiryContent: content))
+        case .multiselect(let content): return .multiselect(.init(enquiryContent: content))
+        case .attachments(let content): return .attachments(.init(enquiryContent: content))
+        case .body, .image, .contactDetails:
+          return nil
         }
       }
     }
@@ -50,8 +107,7 @@ public struct Enquiry: Sendable, Decodable {
 
     public init(from decoder: Decoder) throws {
       let container = try decoder.container(keyedBy: CodingKeys.self)
-      let boxes = try container.decode([ContentBox].self, forKey: .content)
-      self.content = boxes.compactMap(\.value)
+      self.content = try container.decodeSkippingUnknown([Content].self, forKey: .content)
     }
   }
 }

--- a/Sources/Qualtive/Models/Entry+Content.swift
+++ b/Sources/Qualtive/Models/Entry+Content.swift
@@ -60,6 +60,8 @@ extension Entry {
           try container.encode("nps", forKey: .scoreType)
           try container.encode(leadingText, forKey: .leadingText)
           try container.encode(trailingText, forKey: .trailingText)
+        case .stars5:
+          try container.encode("stars5", forKey: .scoreType)
         }
       case .text(let content):
         try container.encode("text", forKey: .type)

--- a/Sources/Qualtive/Models/Error.swift
+++ b/Sources/Qualtive/Models/Error.swift
@@ -5,3 +5,51 @@ struct ParseError: Error, Sendable {
 
   let debugMessage: String
 }
+
+/// Thrown while decoding a list item that should be skipped (unknown API type).
+struct UnknownAPIValueError: Error, Sendable {}
+
+func throwUnknownAPIValue(_ decoder: Decoder) throws -> Never {
+  decoder.loggingController.logHintNewVersion()
+  throw UnknownAPIValueError()
+}
+
+extension Decoder {
+
+  var loggingController: any LoggingControllerType {
+    (userInfo[CodingUserInfoKey.loggingController] as? any LoggingControllerType)
+      ?? LoggingController()
+  }
+}
+
+extension KeyedDecodingContainer {
+
+  /// Decodes an array, skipping items that throw `UnknownAPIValueError`.
+  func decodeSkippingUnknown<T: Decodable>(
+    _ type: [T].Type,
+    forKey key: Key
+  ) throws -> [T] {
+    var unkeyed = try nestedUnkeyedContainer(forKey: key)
+    var values: [T] = []
+    while !unkeyed.isAtEnd {
+      let nested = try unkeyed.superDecoder()
+      do {
+        values.append(try T(from: nested))
+      } catch is UnknownAPIValueError {
+        continue
+      }
+    }
+    return values
+  }
+
+  /// Decodes an array, skipping items that throw `UnknownAPIValueError`.
+  ///
+  /// Missing or null keys decode as an empty array.
+  func decodeSkippingUnknownIfPresent<T: Decodable>(
+    _ type: [T].Type,
+    forKey key: Key
+  ) throws -> [T] {
+    guard contains(key), try !decodeNil(forKey: key) else { return [] }
+    return try decodeSkippingUnknown(type, forKey: key)
+  }
+}

--- a/Sources/Qualtive/Models/Score.swift
+++ b/Sources/Qualtive/Models/Score.swift
@@ -20,7 +20,8 @@ extension Score {
   /// - `smilies3`: 3 user options displayed as smilies
   /// - `thumbs`: 2 user options displayed as up and down thumbs
   /// - `nps`: 11 user options displayed as a range of numbers starting with 0 and ending on 10
-  public enum Kind: Sendable {
+  /// - `stars5`: 5 user options displayed as stars
+  public enum Kind: Sendable, Equatable {
 
     /// 5 user options displayed as smilies
     case smilies5
@@ -33,5 +34,8 @@ extension Score {
 
     /// 11 user options displayed as a range of numbers starting with 0 and ending on 10
     case nps(leadingText: String, trailingText: String)
+
+    /// 5 user options displayed as stars
+    case stars5
   }
 }

--- a/Tests/QualtiveTests/Controllers/EnquiryControllerTests.swift
+++ b/Tests/QualtiveTests/Controllers/EnquiryControllerTests.swift
@@ -16,11 +16,11 @@ struct EnquiryControllerTests {
       #expect(body == nil)
       return (
         jsonData(
-          [
-            "id": 6290486614556672,
-            "slug": "swift",
-            "name": "Swift?",
-            "pages": [
+          enquiryJSON(
+            id: .int64(6290486614556672),
+            slug: "swift",
+            name: "Swift?",
+            pages: [
               [
                 "content": [
                   ["type": "score", "scoreType": "smilies5"],
@@ -28,8 +28,8 @@ struct EnquiryControllerTests {
                   ["type": "text", "placeholder": "Write here…"],
                 ]
               ]
-            ],
-          ] as TestJSON
+            ]
+          )
         ),
         makeHTTPURLResponse(statusCode: 200)
       )
@@ -61,6 +61,24 @@ struct EnquiryControllerTests {
     } else {
       Issue.record("Expected text")
     }
+  }
+
+  @Test func `should append preview token to the path`() async throws {
+    let mock = MockNetworkController()
+    mock.pathHandler = { method, path, _, _, _ in
+      #expect(method == "GET")
+      #expect(path == "/feedback/enquiries/swift/?previewToken=token%20value")
+      return (
+        jsonData(enquiryJSON(slug: "swift", name: "Swift?", pages: [])),
+        makeHTTPURLResponse(statusCode: 200)
+      )
+    }
+
+    let enquiryController = EnquiryController(networkController: mock)
+    _ = try await enquiryController.fetch(
+      collection: "ci-test/swift",
+      previewToken: "token value"
+    )
   }
 
   @Test func `should throw when enquiry is not found`() async {
@@ -103,11 +121,10 @@ struct EnquiryControllerTests {
     mock.pathHandler = { _, _, _, _, _ in
       (
         jsonData(
-          [
-            "id": 1,
-            "slug": "swift",
-            "name": "Swift?",
-            "pages": [
+          enquiryJSON(
+            slug: "swift",
+            name: "Swift?",
+            pages: [
               [
                 "content": [
                   ["type": "title", "text": "Hello"],
@@ -115,8 +132,8 @@ struct EnquiryControllerTests {
                   ["type": "text", "placeholder": "Write"],
                 ]
               ]
-            ],
-          ] as TestJSON
+            ]
+          )
         ),
         makeHTTPURLResponse(statusCode: 200)
       )

--- a/Tests/QualtiveTests/Controllers/EnquiryFetchIntegrationTests.swift
+++ b/Tests/QualtiveTests/Controllers/EnquiryFetchIntegrationTests.swift
@@ -12,6 +12,9 @@ struct EnquiryFetchIntegrationTests {
     #expect(enquiry.slug == "swift")
     #expect(enquiry.id > 0)
     #expect(!enquiry.pages.isEmpty)
+    #expect(!enquiry.submittedPages.isEmpty)
+    #expect(enquiry.container.id == "ci-test")
+    #expect(enquiry.theme.cornerStyle == .rounded || enquiry.theme.cornerStyle == .square)
   }
 
   @Test func `should throw when enquiry is not found`() async {

--- a/Tests/QualtiveTests/Controllers/LoggingControllerTests.swift
+++ b/Tests/QualtiveTests/Controllers/LoggingControllerTests.swift
@@ -14,18 +14,15 @@ struct LoggingControllerTests {
     let enquiry = try decoder.decode(
       Enquiry.self,
       from: jsonData(
-        [
-          "id": 1,
-          "slug": "slug",
-          "name": "Name",
-          "pages": [
+        enquiryJSON(
+          pages: [
             [
               "content": [
                 ["type": "future-content-type", "key": 123]
               ]
             ]
-          ],
-        ] as TestJSON
+          ]
+        )
       )
     )
 
@@ -41,18 +38,15 @@ struct LoggingControllerTests {
     let enquiry = try decoder.decode(
       Enquiry.self,
       from: jsonData(
-        [
-          "id": 1,
-          "slug": "slug",
-          "name": "Name",
-          "pages": [
+        enquiryJSON(
+          pages: [
             [
               "content": [
                 ["type": "score", "scoreType": "future-score"]
               ]
             ]
-          ],
-        ] as TestJSON
+          ]
+        )
       )
     )
 

--- a/Tests/QualtiveTests/Controllers/NetworkControllerTests.swift
+++ b/Tests/QualtiveTests/Controllers/NetworkControllerTests.swift
@@ -148,12 +148,7 @@ struct NetworkControllerTests {
         headerFields: nil
       )!
       let data = jsonData(
-        [
-          "id": 1,
-          "slug": "swift",
-          "name": "Swift?",
-          "pages": [],
-        ] as TestJSON
+        enquiryJSON(slug: "swift", name: "Swift?", pages: [])
       )
       return (data, response)
     }

--- a/Tests/QualtiveTests/Controllers/TestJSON.swift
+++ b/Tests/QualtiveTests/Controllers/TestJSON.swift
@@ -5,6 +5,7 @@ enum TestJSON: Encodable, Equatable {
   case string(String)
   case int(Int)
   case int64(Int64)
+  case bool(Bool)
   case null
   case array([TestJSON])
   case object([String: TestJSON])
@@ -17,6 +18,8 @@ enum TestJSON: Encodable, Equatable {
     case .int(let value):
       try container.encode(value)
     case .int64(let value):
+      try container.encode(value)
+    case .bool(let value):
       try container.encode(value)
     case .null:
       try container.encodeNil()
@@ -37,6 +40,12 @@ extension TestJSON: ExpressibleByStringLiteral {
 extension TestJSON: ExpressibleByIntegerLiteral {
   init(integerLiteral value: Int) {
     self = .int(value)
+  }
+}
+
+extension TestJSON: ExpressibleByBooleanLiteral {
+  init(booleanLiteral value: Bool) {
+    self = .bool(value)
   }
 }
 

--- a/Tests/QualtiveTests/Models/EnquiryCodingTests.swift
+++ b/Tests/QualtiveTests/Models/EnquiryCodingTests.swift
@@ -7,22 +7,147 @@ import Testing
 struct EnquiryCodingTests {
 
   @Test func `should decode with no pages`() throws {
+    let result = try decodeEnquiry(pages: [])
+    #expect(result.id == 1)
+    #expect(result.slug == "enquiry-slug")
+    #expect(result.name == "Enquiry Name")
+    #expect(result.pages.count == 0)
+    #expect(result.submittedPages.isEmpty)
+    #expect(result.isUserContactDetailsRequired == false)
+    #expect(result.theme.cornerStyle == .rounded)
+    #expect(result.container.visibilityMode == .private)
+  }
+
+  @Test func `should decode a full enquiry payload`() throws {
     let result = try JSONDecoder()
       .decode(
         Enquiry.self,
         from: jsonData(
           [
-            "id": 1,
-            "slug": "enquiry-slug",
-            "name": "Enquiry Name",
-            "pages": [],
+            "id": .int64(6290486614556672),
+            "slug": "web",
+            "name": "Web?",
+            "isUserContactDetailsRequired": true,
+            "pages": [
+              [
+                "content": [
+                  [
+                    "type": "score",
+                    "scoreType": "stars5",
+                    "leadingText": "Bad",
+                    "trailingText": "Good",
+                  ],
+                  ["type": "title", "text": "Hello"],
+                  ["type": "body", "text": "Body text"],
+                  [
+                    "type": "image",
+                    "attachment": ["url": "https://example.com/a.png"],
+                  ],
+                  [
+                    "type": "text",
+                    "placeholder": "Write…",
+                    "storageTarget": ["type": "attribute", "attribute": "Age"],
+                  ],
+                  [
+                    "type": "select",
+                    "options": ["A", "B"],
+                    "allowsCustomInput": true,
+                  ],
+                  ["type": "multiselect", "options": ["X", "Y"]],
+                  ["type": "attachments"],
+                  [
+                    "type": "contactDetails",
+                    "title": "Email",
+                    "placeholder": "you@example.com",
+                  ],
+                  ["type": "futureThing", "foo": 1],
+                ]
+              ]
+            ],
+            "submittedPages": [
+              [
+                "conditions": [
+                  [
+                    "type": "score",
+                    "ranges": [["lower": 0, "upper": 50]],
+                  ],
+                  ["type": "futureCondition"],
+                ],
+                "content": [
+                  ["type": "confirmationText", "text": "Thanks!"],
+                  ["type": "name"],
+                  ["type": "userInput"],
+                  ["type": "userInputScore"],
+                  ["type": "link", "text": "Site", "url": "https://example.com"],
+                  [
+                    "type": "reviewLinks",
+                    "links": [
+                      [
+                        "title": "Google",
+                        "url": "https://google.com",
+                        "logo": nil,
+                        "icon": nil,
+                      ]
+                    ],
+                  ],
+                  ["type": "futureSubmitted"],
+                ],
+              ]
+            ],
+            "theme": [
+              "cornerStyle": "rounded",
+              "background": ["type": "predefined", "value": "plain"],
+              "font": ["type": "predefined", "value": "default"],
+              "isBackgroundAttachmentVisibleInResponses": true,
+              "isBackgroundColorVisibleInResponses": false,
+            ],
+            "container": [
+              "id": "ci-test",
+              "isWhiteLabel": false,
+              "customLogos": [],
+              "visibilityMode": "private",
+            ],
           ] as TestJSON
         )
       )
-    #expect(result.id == 1)
-    #expect(result.slug == "enquiry-slug")
-    #expect(result.name == "Enquiry Name")
-    #expect(result.pages.count == 0)
+
+    #expect(result.id == 6290486614556672)
+    #expect(result.slug == "web")
+    #expect(result.name == "Web?")
+    #expect(result.isUserContactDetailsRequired)
+    #expect(result.pages.count == 1)
+    #expect(result.pages[0].content.count == 9)
+
+    if case .score(let score) = result.pages[0].content[0] {
+      #expect(score.kind == .stars5)
+    } else {
+      Issue.record("Expected score")
+    }
+
+    if case .text(let text) = result.pages[0].content[4] {
+      #expect(text.storageTarget == .attribute("Age"))
+    } else {
+      Issue.record("Expected text")
+    }
+
+    if case .select(let select) = result.pages[0].content[5] {
+      #expect(select.allowsCustomInput)
+    } else {
+      Issue.record("Expected select")
+    }
+
+    #expect(result.submittedPages.count == 1)
+    #expect(result.submittedPages[0].conditions.count == 1)
+    if case .score(let condition) = result.submittedPages[0].conditions[0] {
+      #expect(condition.ranges[0].lower == 0)
+      #expect(condition.ranges[0].upper == 50)
+    } else {
+      Issue.record("Expected score condition")
+    }
+    #expect(result.submittedPages[0].content.count == 6)
+    #expect(result.theme.cornerStyle == .rounded)
+    #expect(result.theme.isBackgroundColorVisibleInResponses == false)
+    #expect(result.container.visibilityMode == .private)
   }
 
   @Test func `should decode title content`() throws {
@@ -34,6 +159,40 @@ struct EnquiryCodingTests {
       #expect(content.text == "Your thoughts?")
     } else {
       Issue.record("Expected title")
+    }
+  }
+
+  @Test func `should decode body content`() throws {
+    let result = try decodeEnquiryWithContent([
+      ["type": "body", "text": "More detail"]
+    ])
+    if case .body(let content) = result.pages[0].content[0] {
+      #expect(content.text == "More detail")
+    } else {
+      Issue.record("Expected body")
+    }
+  }
+
+  @Test func `should decode image content`() throws {
+    let result = try decodeEnquiryWithContent([
+      ["type": "image", "attachment": ["url": "https://example.com/a.png"]]
+    ])
+    if case .image(let content) = result.pages[0].content[0] {
+      #expect(content.attachment.url == "https://example.com/a.png")
+    } else {
+      Issue.record("Expected image")
+    }
+  }
+
+  @Test func `should decode contact details content`() throws {
+    let result = try decodeEnquiryWithContent([
+      ["type": "contactDetails", "title": "Email", "placeholder": "you@example.com"]
+    ])
+    if case .contactDetails(let content) = result.pages[0].content[0] {
+      #expect(content.title == "Email")
+      #expect(content.placeholder == "you@example.com")
+    } else {
+      Issue.record("Expected contactDetails")
     }
   }
 
@@ -53,6 +212,7 @@ struct EnquiryCodingTests {
     ])
     if case .text(let content) = result.pages[0].content[0] {
       #expect(content.placeholder == "Write here…")
+      #expect(content.storageTarget == .text)
     } else {
       Issue.record("Expected text")
     }
@@ -69,12 +229,39 @@ struct EnquiryCodingTests {
     }
   }
 
+  @Test func `should decode text storage target attribute`() throws {
+    let result = try decodeEnquiryWithContent([
+      [
+        "type": "text",
+        "placeholder": "Age",
+        "storageTarget": ["type": "attribute", "attribute": "Age"],
+      ]
+    ])
+    if case .text(let content) = result.pages[0].content[0] {
+      #expect(content.storageTarget == .attribute("Age"))
+    } else {
+      Issue.record("Expected text")
+    }
+  }
+
   @Test func `should decode select content`() throws {
     let result = try decodeEnquiryWithContent([
       ["type": "select", "options": ["A", "B", "C"]]
     ])
     if case .select(let content) = result.pages[0].content[0] {
       #expect(content.options == ["A", "B", "C"])
+      #expect(content.allowsCustomInput == false)
+    } else {
+      Issue.record("Expected select")
+    }
+  }
+
+  @Test func `should decode select with custom input`() throws {
+    let result = try decodeEnquiryWithContent([
+      ["type": "select", "options": ["A"], "allowsCustomInput": true]
+    ])
+    if case .select(let content) = result.pages[0].content[0] {
+      #expect(content.allowsCustomInput)
     } else {
       Issue.record("Expected select")
     }
@@ -118,12 +305,10 @@ struct EnquiryCodingTests {
         .decode(
           Enquiry.self,
           from: jsonData(
-            [
-              "id": "not-a-number",
-              "slug": "slug",
-              "name": "Name",
-              "pages": [],
-            ] as TestJSON
+            enquiryJSON(
+              id: "not-a-number",
+              pages: []
+            )
           )
         )
     }
@@ -135,12 +320,10 @@ struct EnquiryCodingTests {
         .decode(
           Enquiry.self,
           from: jsonData(
-            [
-              "id": 1,
-              "slug": "slug",
-              "name": 1,
-              "pages": [],
-            ] as TestJSON
+            enquiryJSON(
+              name: 1,
+              pages: []
+            )
           )
         )
     }
@@ -152,14 +335,11 @@ struct EnquiryCodingTests {
         .decode(
           Enquiry.self,
           from: jsonData(
-            [
-              "id": 1,
-              "slug": "slug",
-              "name": "Name",
-              "pages": [
+            enquiryJSON(
+              pages: [
                 ["content": [["type": "title"]]]
-              ],
-            ] as TestJSON
+              ]
+            )
           )
         )
     }
@@ -170,10 +350,7 @@ struct EnquiryCodingTests {
       ["type": "score", "scoreType": "smilies3"]
     ])
     if case .score(let content) = result.pages[0].content[0] {
-      if case .smilies3 = content.kind {
-      } else {
-        Issue.record("Expected smilies3")
-      }
+      #expect(content.kind == .smilies3)
     } else {
       Issue.record("Expected score")
     }
@@ -184,16 +361,13 @@ struct EnquiryCodingTests {
       ["type": "score", "scoreType": "thumbs"]
     ])
     if case .score(let content) = result.pages[0].content[0] {
-      if case .thumbs = content.kind {
-      } else {
-        Issue.record("Expected thumbs")
-      }
+      #expect(content.kind == .thumbs)
     } else {
       Issue.record("Expected score")
     }
   }
 
-  @Test func `should decode nps score content`() throws {
+  @Test func `should decode nps score content with labels`() throws {
     let result = try decodeEnquiryWithContent([
       [
         "type": "score",
@@ -214,7 +388,7 @@ struct EnquiryCodingTests {
     }
   }
 
-  @Test func `should default nps labels when missing`() throws {
+  @Test func `should decode nps without labels`() throws {
     let result = try decodeEnquiryWithContent([
       ["type": "score", "scoreType": "nps"]
     ])
@@ -230,15 +404,29 @@ struct EnquiryCodingTests {
     }
   }
 
-  @Test func `should flatten all content kinds into an entry content template`() throws {
+  @Test func `should decode stars5 score content`() throws {
+    let result = try decodeEnquiryWithContent([
+      ["type": "score", "scoreType": "stars5"]
+    ])
+    if case .score(let content) = result.pages[0].content[0] {
+      #expect(content.kind == .stars5)
+    } else {
+      Issue.record("Expected score")
+    }
+  }
+
+  @Test func `should flatten input content into an entry content template`() throws {
     let enquiry = try decodeEnquiryWithContent(
       [
         ["type": "title", "text": "Title"],
+        ["type": "body", "text": "Body"],
+        ["type": "image", "attachment": ["url": "https://example.com/a.png"]],
         ["type": "score", "scoreType": "smilies5"],
         ["type": "text", "placeholder": "Write"],
         ["type": "select", "options": ["A"]],
         ["type": "multiselect", "options": ["B"]],
         ["type": "attachments"],
+        ["type": "contactDetails", "title": "Email"],
       ] as TestJSON
     )
     let template = enquiry.entryContentTemplate()
@@ -266,30 +454,21 @@ struct EnquiryCodingTests {
   }
 
   @Test func `should flatten pages into an entry content template`() throws {
-    let enquiry = try JSONDecoder()
-      .decode(
-        Enquiry.self,
-        from: jsonData(
-          [
-            "id": 1,
-            "slug": "slug",
-            "name": "Name",
-            "pages": [
-              [
-                "content": [
-                  ["type": "title", "text": "Page 1"],
-                  ["type": "score", "scoreType": "smilies5"],
-                ]
-              ],
-              [
-                "content": [
-                  ["type": "text", "placeholder": "More"]
-                ]
-              ],
-            ],
-          ] as TestJSON
-        )
-      )
+    let enquiry = try decodeEnquiry(
+      pages: [
+        [
+          "content": [
+            ["type": "title", "text": "Page 1"],
+            ["type": "score", "scoreType": "smilies5"],
+          ]
+        ],
+        [
+          "content": [
+            ["type": "text", "placeholder": "More"]
+          ]
+        ],
+      ]
+    )
 
     let template = enquiry.entryContentTemplate()
     #expect(template.count == 3)
@@ -310,21 +489,101 @@ struct EnquiryCodingTests {
       Issue.record("Expected text")
     }
   }
+
+  @Test func `should default unknown theme and container enums`() throws {
+    let result = try decodeEnquiry(
+      pages: [],
+      theme: [
+        "cornerStyle": "hexagon",
+        "background": ["type": "predefined", "value": "neon"],
+        "font": ["type": "predefined", "value": "default"],
+      ],
+      container: [
+        "id": "c",
+        "visibilityMode": "secret",
+        "customLogos": [
+          [
+            "size": "round",
+            "intendedBackground": "light",
+            "primaryColor": "#fff",
+            "urlVector": "https://logo.svg",
+          ],
+          [
+            "size": "wide",
+            "intendedBackground": "light",
+            "primaryColor": "#fff",
+            "urlVector": "https://logo.svg",
+          ],
+        ],
+      ]
+    )
+    #expect(result.theme.cornerStyle == .rounded)
+    if case .predefined(let value) = result.theme.background {
+      #expect(value == .plain)
+    } else {
+      Issue.record("Expected predefined background")
+    }
+    #expect(result.container.visibilityMode == .private)
+    #expect(result.container.customLogos.count == 1)
+  }
 }
 
 private func decodeEnquiryWithContent(_ content: TestJSON) throws -> Enquiry {
+  try decodeEnquiry(pages: [["content": content]])
+}
+
+private func decodeEnquiry(
+  id: TestJSON = 1,
+  slug: TestJSON = "enquiry-slug",
+  name: TestJSON = "Enquiry Name",
+  pages: TestJSON,
+  theme: TestJSON? = nil,
+  container: TestJSON? = nil
+) throws -> Enquiry {
   try JSONDecoder()
     .decode(
       Enquiry.self,
       from: jsonData(
-        [
-          "id": 1,
-          "slug": "enquiry-slug",
-          "name": "Enquiry Name",
-          "pages": [
-            ["content": content]
-          ],
-        ] as TestJSON
+        enquiryJSON(
+          id: id,
+          slug: slug,
+          name: name,
+          pages: pages,
+          theme: theme,
+          container: container
+        )
       )
     )
+}
+
+func enquiryJSON(
+  id: TestJSON = 1,
+  slug: TestJSON = "enquiry-slug",
+  name: TestJSON = "Enquiry Name",
+  pages: TestJSON,
+  theme: TestJSON? = nil,
+  container: TestJSON? = nil
+) -> TestJSON {
+  [
+    "id": id,
+    "slug": slug,
+    "name": name,
+    "pages": pages,
+    "submittedPages": [],
+    "theme": theme
+      ?? [
+        "cornerStyle": "rounded",
+        "background": ["type": "predefined", "value": "plain"],
+        "font": ["type": "predefined", "value": "default"],
+        "isBackgroundAttachmentVisibleInResponses": true,
+        "isBackgroundColorVisibleInResponses": true,
+      ],
+    "container": container
+      ?? [
+        "id": "ci-test",
+        "isWhiteLabel": false,
+        "customLogos": [],
+        "visibilityMode": "private",
+      ],
+  ]
 }

--- a/Tests/QualtiveTests/Models/EntryContentTests.swift
+++ b/Tests/QualtiveTests/Models/EntryContentTests.swift
@@ -55,6 +55,15 @@ struct EntryContentTests {
     #expect(encoded.scoreType == "thumbs")
   }
 
+  @Test func `should encode stars5 score type`() throws {
+    let encoded = try encode(
+      .score(.init(enquiryContent: .init(kind: .stars5)))
+    )
+    #expect(encoded.scoreType == "stars5")
+    #expect(encoded.leadingText == nil)
+    #expect(encoded.trailingText == nil)
+  }
+
   @Test func `should encode attachment values`() throws {
     let encoded = try encode(.attachments(.init(values: [Attachment(id: 7)])))
     #expect(encoded.type == "attachments")


### PR DESCRIPTION
## Summary
- Decode the full enquiry fetch payload: `theme`, `container`, `submittedPages` (with score conditions), and `isUserContactDetailsRequired`.
- Add remaining page content types (`body`, `image`, `contactDetails`, `stars5`, select `allowsCustomInput`, text `storageTarget`) and optional `previewToken` on fetch.
- Unknown content types still skip and log a new-version hint.

## Test plan
- [x] `swift test` (unit + live enquiry fetch)
- [ ] Confirm a real enquiry with mixed content types decodes without dropping known fields