### PR TITLE
Align posting, privacy, and attachments with Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ All notable changes to this project will be documented in this file.
 - Full enquiry fetch model: `theme`, `container`, `submittedPages` (with score conditions), and `isUserContactDetailsRequired`.
 - Page content types `body`, `image`, and `contactDetails`; select `allowsCustomInput`; text `storageTarget`; and score `stars5`.
 - Optional `previewToken` on `EnquiryController.fetch` for unpublished drafts.
+- Per-post `PostOptions` for `metadataCollection` and `userTrackingConsent`.
+- Attachment uploads from a local file URL, and arbitrary MIME types (not only PNG/JPEG).
+
+### Fixed
+
+- Text fields with `storageTarget` `.attribute` are posted as attributes, not as text content.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -77,11 +77,8 @@ The public API is split into focused controllers you can also inject via protoco
 - `EnquiryController` / `EnquiryControllerType` — fetch enquiry definitions
 - `PostController` / `PostControllerType` — post entries
 - `AttachmentController` / `AttachmentControllerType` — upload attachments
-- `StandardAttributesController` / `StandardAttributesControllerType` — device/app attributes collected on post
-- `UserClientIDController` / `UserClientIDControllerType` — persisted per-device client id
-- `LoggingController` / `LoggingControllerType` — diagnostic logging
 
-Default inits wire production networking and related controllers. For custom UI later, pass these into your views.
+Default inits wire production networking. For custom UI later, pass these into your views.
 
 ### User data
 
@@ -119,6 +116,42 @@ try await PostController().post(
 ```
 
 `Attributes` is dictionary-backed and expressible by dictionary literal, with typed keys such as `.platform`, `.os`, and `.appId`.
+
+Privacy options apply to that post only. By default, non-personal device/app attributes are attached and a per-device client id is stored. You can turn either off:
+
+```swift
+try await PostController().post(
+  to: "my-company/my-enquiry",
+  content: [
+    .text(.init(value: "Hello")),
+  ],
+  options: PostOptions(
+    metadataCollection: .none,
+    userTrackingConsent: .denied
+  )
+)
+```
+
+Attachments (for example from the photo picker or a file URL) upload first, then reference the returned id:
+
+```swift
+let image = try await AttachmentController().create(
+  from: .data(pngData, contentType: .png),
+  to: "my-company"
+)
+let video = try await AttachmentController().create(
+  from: .file(fileURL, contentType: "video/mp4"),
+  to: "my-company"
+)
+try await PostController().post(
+  to: "my-company/my-enquiry",
+  content: [
+    .attachments(.init(values: [image, video])),
+  ]
+)
+```
+
+Any MIME type is accepted. Prefer `.file` for large payloads so the bytes are streamed from disk.
 
 ## Supported platforms
 

--- a/Sources/Qualtive/Controllers/AttachmentController.swift
+++ b/Sources/Qualtive/Controllers/AttachmentController.swift
@@ -31,19 +31,13 @@ public struct AttachmentController: AttachmentControllerType {
     from upload: Attachment.Upload,
     to containerId: ContainerId
   ) async throws -> Attachment {
-    let contentType: String
-    switch upload {
-    case .data(_, let kind):
-      contentType = kind.mimeType
-    }
-
     let created: CreatedAttachment
     do {
       created = try await networkController.send(
         method: "POST",
         path: "/feedback/attachments/",
         containerId: containerId.rawValue,
-        body: CreateAttachmentRequest(contentType: contentType)
+        body: CreateAttachmentRequest(contentType: contentType(of: upload).mimeType)
       )
     } catch let error as NetworkError {
       throw UploadError.network(error)
@@ -52,29 +46,48 @@ public struct AttachmentController: AttachmentControllerType {
     try await uploadBytes(upload, to: created.uploadURL)
     return Attachment(id: created.id)
   }
+}
+
+private func contentType(of upload: Attachment.Upload) -> Attachment.ContentType {
+  switch upload {
+  case .data(_, let contentType), .file(_, let contentType):
+    return contentType
+  }
+}
+
+extension AttachmentController {
 
   private func uploadBytes(
     _ upload: Attachment.Upload,
     to uploadURL: URL
   ) async throws {
-    let headers: [String: String]
-    let body: Data
-    switch upload {
-    case .data(let data, let kind):
-      headers = ["Content-Type": kind.mimeType]
-      body = data
-    }
-
     let response: HTTPURLResponse
     do {
-      (_, response) = try await networkController.send(
-        method: "PUT",
-        url: uploadURL,
-        headers: headers,
-        body: body
-      )
+      switch upload {
+      case .data(let data, let contentType):
+        (_, response) = try await networkController.send(
+          method: "PUT",
+          url: uploadURL,
+          headers: ["Content-Type": contentType.mimeType],
+          body: data
+        )
+      case .file(let fileURL, let contentType):
+        guard fileURL.isFileURL else {
+          throw UploadError.network(
+            .unexpected(ParseError(debugMessage: "Attachment file URL must be a file URL"))
+          )
+        }
+        (_, response) = try await networkController.send(
+          method: "PUT",
+          url: uploadURL,
+          headers: ["Content-Type": contentType.mimeType],
+          fileURL: fileURL
+        )
+      }
     } catch let error as NetworkError {
       throw UploadError.network(error)
+    } catch let error as UploadError {
+      throw error
     }
 
     switch response.statusCode {

--- a/Sources/Qualtive/Controllers/LoggingController.swift
+++ b/Sources/Qualtive/Controllers/LoggingController.swift
@@ -2,18 +2,18 @@ import Foundation
 import os
 
 /// Logs library diagnostics such as hints about newer SDK versions.
-public protocol LoggingControllerType: Sendable {
+protocol LoggingControllerType: Sendable {
 
   /// Logs that the client may need updating when an unknown API value is encountered.
   func logHintNewVersion()
 }
 
 /// Default logging using the system unified logging facility.
-public struct LoggingController: LoggingControllerType {
+struct LoggingController: LoggingControllerType {
 
-  public init() {}
+  init() {}
 
-  public func logHintNewVersion() {
+  func logHintNewVersion() {
     let text: StaticString =
       "There may be a new version of the Qualtive Client Library - Swift. Please update to get the latest features and fixes."
     os_log(text, log: .qualtive)

--- a/Sources/Qualtive/Controllers/NetworkController.swift
+++ b/Sources/Qualtive/Controllers/NetworkController.swift
@@ -38,6 +38,39 @@ package protocol NetworkControllerType: Sendable {
     headers: [String: String],
     body: Data?
   ) async throws -> (Data, HTTPURLResponse)
+
+  /// Performs an HTTP request against an absolute URL, streaming the body from a local file.
+  ///
+  /// Throws `NetworkError`, or `CancellationError` when the task/request is cancelled.
+  func send(
+    method: String,
+    url: URL,
+    headers: [String: String],
+    fileURL: URL
+  ) async throws -> (Data, HTTPURLResponse)
+}
+
+extension NetworkControllerType {
+
+  package func send(
+    method: String,
+    url: URL,
+    headers: [String: String],
+    fileURL: URL
+  ) async throws -> (Data, HTTPURLResponse) {
+    let body: Data
+    do {
+      body = try Data(contentsOf: fileURL)
+    } catch {
+      throw NetworkError.connection(error)
+    }
+    return try await send(
+      method: method,
+      url: url,
+      headers: headers,
+      body: body
+    )
+  }
 }
 
 extension NetworkControllerType {
@@ -181,6 +214,29 @@ package struct NetworkController: NetworkControllerType {
     headers: [String: String],
     body: Data?
   ) async throws -> (Data, HTTPURLResponse) {
+    var urlRequest = makeURLRequest(method: method, url: url, headers: headers)
+    urlRequest.httpBody = body
+    return try await execute(urlRequest)
+  }
+
+  package func send(
+    method: String,
+    url: URL,
+    headers: [String: String],
+    fileURL: URL
+  ) async throws -> (Data, HTTPURLResponse) {
+    let urlRequest = makeURLRequest(method: method, url: url, headers: headers)
+    return try await execute(urlRequest, fromFile: fileURL)
+  }
+}
+
+extension NetworkController {
+
+  private func makeURLRequest(
+    method: String,
+    url: URL,
+    headers: [String: String]
+  ) -> URLRequest {
     var urlRequest = URLRequest(
       url: url,
       cachePolicy: .useProtocolCachePolicy,
@@ -190,8 +246,10 @@ package struct NetworkController: NetworkControllerType {
     for (key, value) in headers {
       urlRequest.addValue(value, forHTTPHeaderField: key)
     }
-    urlRequest.httpBody = body
+    return urlRequest
+  }
 
+  private func execute(_ urlRequest: URLRequest) async throws -> (Data, HTTPURLResponse) {
     let data: Data
     let response: URLResponse
     do {
@@ -199,14 +257,31 @@ package struct NetworkController: NetworkControllerType {
     } catch {
       try mapNetworkTransportError(error)
     }
-
-    guard let httpResponse = response as? HTTPURLResponse else {
-      throw NetworkError.unexpected(
-        ParseError(debugMessage: "Response is not HTTP")
-      )
-    }
-    return (data, httpResponse)
+    return try httpResponse(data, response)
   }
+
+  private func execute(
+    _ urlRequest: URLRequest,
+    fromFile fileURL: URL
+  ) async throws -> (Data, HTTPURLResponse) {
+    let data: Data
+    let response: URLResponse
+    do {
+      (data, response) = try await urlSession.upload(for: urlRequest, fromFile: fileURL)
+    } catch {
+      try mapNetworkTransportError(error)
+    }
+    return try httpResponse(data, response)
+  }
+}
+
+private func httpResponse(_ data: Data, _ response: URLResponse) throws -> (Data, HTTPURLResponse) {
+  guard let httpResponse = response as? HTTPURLResponse else {
+    throw NetworkError.unexpected(
+      ParseError(debugMessage: "Response is not HTTP")
+    )
+  }
+  return (data, httpResponse)
 }
 
 private func mapNetworkTransportError(_ error: Error) throws -> Never {

--- a/Sources/Qualtive/Controllers/PostController.swift
+++ b/Sources/Qualtive/Controllers/PostController.swift
@@ -4,13 +4,17 @@ import Foundation
 public protocol PostControllerType: Sendable {
 
   /// Posts an entry to qualtive.io.
+  ///
+  /// Text sections whose enquiry definition uses `storageTarget` `.attribute` are sent as
+  /// attributes, not as text content.
   /// - Throws: `PostError`, or `CancellationError` when cancelled.
   func post(
     to collection: Collection,
     content: [Entry.Content],
     user: User,
     customAttributes: Attributes,
-    locale: Locale
+    locale: Locale,
+    options: PostOptions
   ) async throws -> Entry
 }
 
@@ -25,7 +29,8 @@ extension PostControllerType {
       content: content,
       user: User(),
       customAttributes: [:],
-      locale: .current
+      locale: .current,
+      options: PostOptions()
     )
   }
 
@@ -39,7 +44,8 @@ extension PostControllerType {
       content: content,
       user: user,
       customAttributes: [:],
-      locale: .current
+      locale: .current,
+      options: PostOptions()
     )
   }
 
@@ -53,7 +59,8 @@ extension PostControllerType {
       content: content,
       user: User(),
       customAttributes: customAttributes,
-      locale: .current
+      locale: .current,
+      options: PostOptions()
     )
   }
 
@@ -68,7 +75,73 @@ extension PostControllerType {
       content: content,
       user: user,
       customAttributes: customAttributes,
-      locale: .current
+      locale: .current,
+      options: PostOptions()
+    )
+  }
+
+  public func post(
+    to collection: Collection,
+    content: [Entry.Content],
+    user: User,
+    customAttributes: Attributes,
+    locale: Locale
+  ) async throws -> Entry {
+    try await post(
+      to: collection,
+      content: content,
+      user: user,
+      customAttributes: customAttributes,
+      locale: locale,
+      options: PostOptions()
+    )
+  }
+
+  public func post(
+    to collection: Collection,
+    content: [Entry.Content],
+    options: PostOptions
+  ) async throws -> Entry {
+    try await post(
+      to: collection,
+      content: content,
+      user: User(),
+      customAttributes: [:],
+      locale: .current,
+      options: options
+    )
+  }
+
+  public func post(
+    to collection: Collection,
+    content: [Entry.Content],
+    customAttributes: Attributes,
+    options: PostOptions
+  ) async throws -> Entry {
+    try await post(
+      to: collection,
+      content: content,
+      user: User(),
+      customAttributes: customAttributes,
+      locale: .current,
+      options: options
+    )
+  }
+
+  public func post(
+    to collection: Collection,
+    content: [Entry.Content],
+    user: User,
+    customAttributes: Attributes,
+    options: PostOptions
+  ) async throws -> Entry {
+    try await post(
+      to: collection,
+      content: content,
+      user: user,
+      customAttributes: customAttributes,
+      locale: .current,
+      options: options
     )
   }
 }
@@ -101,7 +174,7 @@ public struct PostController: PostControllerType {
     )
   }
 
-  package init(
+  init(
     networkController: some NetworkControllerType,
     standardAttributesController: some StandardAttributesControllerType,
     userClientIDController: some UserClientIDControllerType
@@ -116,16 +189,28 @@ public struct PostController: PostControllerType {
     content: [Entry.Content],
     user: User,
     customAttributes: Attributes,
-    locale: Locale
+    locale: Locale,
+    options: PostOptions
   ) async throws -> Entry {
-    var attributes = await standardAttributesController.makeAttributes(locale: locale)
+    var attributes = Attributes()
+    if options.metadataCollection == .nonPersonal {
+      attributes = await standardAttributesController.makeAttributes(locale: locale)
+    }
     attributes.merge(customAttributes)
+    attributes.merge(attributesFromContent(content))
+
+    let clientId: String?
+    if options.userTrackingConsent == .granted {
+      clientId = userClientIDController.clientId()
+    } else {
+      clientId = nil
+    }
 
     let request = PostEntryRequest(
       questionId: collection.enquiryId.rawValue,
-      content: content,
+      content: contentForPost(content),
       user: .init(
-        clientId: userClientIDController.clientId(),
+        clientId: clientId,
         timeZoneIdentifier: TimeZone.current.identifier,
         id: user.id,
         name: user.name,
@@ -157,6 +242,30 @@ private func mapPostError(_ error: NetworkError) -> PostController.PostError {
   }
 }
 
+private func contentForPost(_ content: [Entry.Content]) -> [Entry.Content] {
+  content.filter { section in
+    if case .text(let text) = section,
+      case .attribute = text.definition.storageTarget
+    {
+      return false
+    }
+    return true
+  }
+}
+
+private func attributesFromContent(_ content: [Entry.Content]) -> Attributes {
+  var result = Attributes()
+  for section in content {
+    guard case .text(let text) = section,
+      case .attribute(let name) = text.definition.storageTarget
+    else { continue }
+    guard let value = text.value, !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    else { continue }
+    result[name] = value
+  }
+  return result
+}
+
 private struct PostEntryRequest: Encodable {
 
   let questionId: String
@@ -166,11 +275,28 @@ private struct PostEntryRequest: Encodable {
   let attributeHints: AttributeHints
 
   struct UserPayload: Encodable {
-    let clientId: String
+    let clientId: String?
     let timeZoneIdentifier: String
     let id: String?
     let name: String?
     let email: String?
+
+    private enum CodingKeys: String, CodingKey {
+      case clientId
+      case timeZoneIdentifier
+      case id
+      case name
+      case email
+    }
+
+    func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encodeIfPresent(clientId, forKey: .clientId)
+      try container.encode(timeZoneIdentifier, forKey: .timeZoneIdentifier)
+      try container.encodeIfPresent(id, forKey: .id)
+      try container.encodeIfPresent(name, forKey: .name)
+      try container.encodeIfPresent(email, forKey: .email)
+    }
   }
 
   struct AttributeHints: Encodable {

--- a/Sources/Qualtive/Controllers/StandardAttributesController.swift
+++ b/Sources/Qualtive/Controllers/StandardAttributesController.swift
@@ -5,24 +5,24 @@ import Foundation
 #endif
 
 /// Produces the standard device/app attributes collected when posting feedback.
-public protocol StandardAttributesControllerType: Sendable {
+protocol StandardAttributesControllerType: Sendable {
 
   func makeAttributes(locale: Locale) async -> Attributes
 }
 
 extension StandardAttributesControllerType {
 
-  public func makeAttributes() async -> Attributes {
+  func makeAttributes() async -> Attributes {
     await makeAttributes(locale: .current)
   }
 }
 
 /// Collects platform, device, app, and locale attributes.
-public struct StandardAttributesController: StandardAttributesControllerType {
+struct StandardAttributesController: StandardAttributesControllerType {
 
-  public init() {}
+  init() {}
 
-  public func makeAttributes(locale: Locale) async -> Attributes {
+  func makeAttributes(locale: Locale) async -> Attributes {
     var attributes = Attributes()
 
     if let value = platform() { attributes[.platform] = value }

--- a/Sources/Qualtive/Controllers/UserClientIDController.swift
+++ b/Sources/Qualtive/Controllers/UserClientIDController.swift
@@ -1,27 +1,27 @@
 import Foundation
 
 /// Provides a stable per-device client identifier for posted entries.
-public protocol UserClientIDControllerType: Sendable {
+protocol UserClientIDControllerType: Sendable {
 
   func clientId() -> String
 }
 
 /// Persists a unique client id in `UserDefaults`.
-public struct UserClientIDController: UserClientIDControllerType {
+struct UserClientIDController: UserClientIDControllerType {
 
   private let storageKey: String
   private let suiteName: String?
 
-  public init() {
+  init() {
     self.init(storageKey: "_qualtiveCID", suiteName: nil)
   }
 
-  package init(storageKey: String, suiteName: String?) {
+  init(storageKey: String, suiteName: String?) {
     self.storageKey = storageKey
     self.suiteName = suiteName
   }
 
-  public func clientId() -> String {
+  func clientId() -> String {
     let userDefaults = self.userDefaults()
     if let existing = userDefaults.string(forKey: storageKey), !existing.isEmpty {
       return existing

--- a/Sources/Qualtive/Models/Attachment.swift
+++ b/Sources/Qualtive/Models/Attachment.swift
@@ -9,19 +9,36 @@ public struct Attachment: Sendable, Codable {
     self.id = id
   }
 
-  public enum Upload: Sendable {
-    case data(Data, kind: Kind)
+  /// MIME type for an uploaded attachment.
+  ///
+  /// Any MIME string is accepted (for example `application/pdf`, `video/mp4`, `image/jpeg`).
+  public struct ContentType: Sendable, Hashable, ExpressibleByStringLiteral, CustomStringConvertible
+  {
 
-    public enum Kind: Sendable {
-      case png
-      case jpeg
+    public let mimeType: String
 
-      var mimeType: String {
-        switch self {
-        case .jpeg: return "image/jpeg"
-        case .png: return "image/png"
-        }
-      }
+    public init(_ mimeType: String) {
+      self.mimeType = mimeType
     }
+
+    public init(stringLiteral value: String) {
+      self.init(value)
+    }
+
+    public var description: String { mimeType }
+
+    /// Convenience for `image/png`.
+    public static let png = ContentType("image/png")
+
+    /// Convenience for `image/jpeg`.
+    public static let jpeg = ContentType("image/jpeg")
+  }
+
+  public enum Upload: Sendable {
+    /// Bytes already in memory. Prefer `file` for large payloads such as video.
+    case data(Data, contentType: ContentType)
+
+    /// Local file URL. Streamed from disk; the full file is not buffered in memory.
+    case file(URL, contentType: ContentType)
   }
 }

--- a/Sources/Qualtive/Models/PostOptions.swift
+++ b/Sources/Qualtive/Models/PostOptions.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Per-post options for `PostController`.
+///
+/// - Parameters:
+///   - metadataCollection: Whether to attach device/app attributes. Defaults to
+///     `MetadataCollection.nonPersonal`.
+///   - userTrackingConsent: Whether a persisted client id may be stored/sent. Defaults to
+///     `UserTrackingConsent.granted`.
+public struct PostOptions: Sendable, Equatable {
+
+  /// Whether to attach device and app attributes.
+  public var metadataCollection: MetadataCollection
+
+  /// Whether a persisted client id may be stored and sent.
+  public var userTrackingConsent: UserTrackingConsent
+
+  public init(
+    metadataCollection: MetadataCollection = .nonPersonal,
+    userTrackingConsent: UserTrackingConsent = .granted
+  ) {
+    self.metadataCollection = metadataCollection
+    self.userTrackingConsent = userTrackingConsent
+  }
+}
+
+/// How much non-user metadata may be attached for a single post.
+///
+/// Independent of `UserTrackingConsent`, which only controls a persisted client id.
+public enum MetadataCollection: Sendable, Equatable {
+  /// Device and app attributes (for example `Platform`, `OS Version`).
+  case nonPersonal
+
+  /// No automatic metadata.
+  case none
+}
+
+/// Whether the user has consented to a persisted client id for a single post.
+///
+/// `denied` means no client id is stored or sent. Device/app metadata is controlled separately
+/// by `MetadataCollection`.
+public enum UserTrackingConsent: Sendable, Equatable {
+  case granted
+  case denied
+}

--- a/Tests/QualtiveTests/Controllers/AttachmentControllerTests.swift
+++ b/Tests/QualtiveTests/Controllers/AttachmentControllerTests.swift
@@ -30,7 +30,7 @@ struct AttachmentControllerTests {
 
     let attachmentController = AttachmentController(networkController: mock)
     let attachment = try await attachmentController.create(
-      from: .data(Data([0x89, 0x50]), kind: .png),
+      from: .data(Data([0x89, 0x50]), contentType: .png),
       to: "ci-test"
     )
 
@@ -57,7 +57,7 @@ struct AttachmentControllerTests {
 
     let attachment = try await AttachmentController(networkController: mock)
       .create(
-        from: .data(Data([0xFF, 0xD8]), kind: .jpeg),
+        from: .data(Data([0xFF, 0xD8]), contentType: .jpeg),
         to: "ci-test"
       )
     #expect(attachment.id == 3)
@@ -75,7 +75,7 @@ struct AttachmentControllerTests {
     let attachmentController = AttachmentController(networkController: mock)
     await #expect {
       _ = try await attachmentController.create(
-        from: .data(Data(), kind: .png),
+        from: .data(Data(), contentType: .png),
         to: "ci-test"
       )
     } throws: { error in
@@ -97,7 +97,7 @@ struct AttachmentControllerTests {
     let attachmentController = AttachmentController(networkController: mock)
     await #expect {
       _ = try await attachmentController.create(
-        from: .data(Data(), kind: .jpeg),
+        from: .data(Data(), contentType: .jpeg),
         to: "ci-test"
       )
     } throws: { error in
@@ -126,7 +126,7 @@ struct AttachmentControllerTests {
     let attachmentController = AttachmentController(networkController: mock)
     await #expect {
       _ = try await attachmentController.create(
-        from: .data(Data(), kind: .png),
+        from: .data(Data(), contentType: .png),
         to: "ci-test"
       )
     } throws: { error in
@@ -155,7 +155,7 @@ struct AttachmentControllerTests {
     let attachmentController = AttachmentController(networkController: mock)
     await #expect {
       _ = try await attachmentController.create(
-        from: .data(Data(), kind: .png),
+        from: .data(Data(), contentType: .png),
         to: "ci-test"
       )
     } throws: { error in
@@ -177,12 +177,95 @@ struct AttachmentControllerTests {
     let attachmentController = AttachmentController(networkController: mock)
     await #expect {
       _ = try await attachmentController.create(
-        from: .data(Data(), kind: .png),
+        from: .data(Data(), contentType: .png),
         to: "ci-test"
       )
     } throws: { error in
       guard let error = error as? AttachmentController.UploadError,
         case .network(.connection) = error
+      else {
+        return false
+      }
+      return true
+    }
+  }
+
+  @Test func `should upload an arbitrary mime type`() async throws {
+    let uploadURL = URL(string: "https://uploads.example/put")!
+    let mock = MockNetworkController()
+    mock.pathHandler = { _, _, _, _, body in
+      let request = decodeJSON(CreateAttachmentBody.self, from: body!)
+      #expect(request.contentType == "application/pdf")
+      return (
+        jsonData(CreatedAttachmentBody(id: 8, uploadUrl: uploadURL.absoluteString)),
+        makeHTTPURLResponse(statusCode: 200)
+      )
+    }
+    mock.urlHandler = { _, _, headers, body in
+      #expect(headers["Content-Type"] == "application/pdf")
+      #expect(body == Data([0x25, 0x50, 0x44, 0x46]))
+      return (Data(), makeHTTPURLResponse(url: uploadURL, statusCode: 200))
+    }
+
+    let attachment = try await AttachmentController(networkController: mock)
+      .create(
+        from: .data(Data([0x25, 0x50, 0x44, 0x46]), contentType: "application/pdf"),
+        to: "ci-test"
+      )
+    #expect(attachment.id == 8)
+  }
+
+  @Test func `should upload a file url`() async throws {
+    let uploadURL = URL(string: "https://uploads.example/put")!
+    let bytes = Data([0x00, 0x01, 0x02])
+    let fileURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent("qualtive-upload-\(UUID().uuidString).bin")
+    try bytes.write(to: fileURL)
+    defer { try? FileManager.default.removeItem(at: fileURL) }
+
+    let mock = MockNetworkController()
+    mock.pathHandler = { _, _, _, _, body in
+      let request = decodeJSON(CreateAttachmentBody.self, from: body!)
+      #expect(request.contentType == "video/mp4")
+      return (
+        jsonData(CreatedAttachmentBody(id: 11, uploadUrl: uploadURL.absoluteString)),
+        makeHTTPURLResponse(statusCode: 200)
+      )
+    }
+    mock.urlHandler = { _, _, headers, body in
+      #expect(headers["Content-Type"] == "video/mp4")
+      #expect(body == bytes)
+      return (Data(), makeHTTPURLResponse(url: uploadURL, statusCode: 200))
+    }
+
+    let attachment = try await AttachmentController(networkController: mock)
+      .create(
+        from: .file(fileURL, contentType: "video/mp4"),
+        to: "ci-test"
+      )
+    #expect(attachment.id == 11)
+  }
+
+  @Test func `should throw when the file url is not a file url`() async {
+    let mock = MockNetworkController()
+    mock.pathHandler = { _, _, _, _, _ in
+      (
+        jsonData(
+          CreatedAttachmentBody(id: 1, uploadUrl: "https://uploads.example/put")
+        ),
+        makeHTTPURLResponse(statusCode: 200)
+      )
+    }
+
+    let attachmentController = AttachmentController(networkController: mock)
+    await #expect {
+      _ = try await attachmentController.create(
+        from: .file(URL(string: "https://example.com/a.png")!, contentType: .png),
+        to: "ci-test"
+      )
+    } throws: { error in
+      guard let error = error as? AttachmentController.UploadError,
+        case .network(.unexpected) = error
       else {
         return false
       }

--- a/Tests/QualtiveTests/Controllers/AttachmentUploadIntegrationTests.swift
+++ b/Tests/QualtiveTests/Controllers/AttachmentUploadIntegrationTests.swift
@@ -10,7 +10,18 @@ struct AttachmentUploadIntegrationTests {
     let png = try onePixelPNG()
     let attachment = try await AttachmentController()
       .create(
-        from: .data(png, kind: .png),
+        from: .data(png, contentType: .png),
+        to: "ci-test"
+      )
+
+    #expect(attachment.id > 0)
+  }
+
+  @Test func `should upload a png from a file url`() async throws {
+    let fileURL = try #require(Bundle.module.url(forResource: "1px", withExtension: "png"))
+    let attachment = try await AttachmentController()
+      .create(
+        from: .file(fileURL, contentType: .png),
         to: "ci-test"
       )
 
@@ -21,7 +32,7 @@ struct AttachmentUploadIntegrationTests {
     let png = try onePixelPNG()
     let attachment = try await AttachmentController()
       .create(
-        from: .data(png, kind: .png),
+        from: .data(png, contentType: .png),
         to: "ci-test"
       )
 
@@ -45,7 +56,7 @@ struct AttachmentUploadIntegrationTests {
     )
     await #expect {
       _ = try await attachmentController.create(
-        from: .data(Data(), kind: .png),
+        from: .data(Data(), contentType: .png),
         to: "ci-test"
       )
     } throws: { error in

--- a/Tests/QualtiveTests/Controllers/NetworkControllerTests.swift
+++ b/Tests/QualtiveTests/Controllers/NetworkControllerTests.swift
@@ -191,6 +191,44 @@ struct NetworkControllerTests {
     )
     #expect(result.id == 1)
   }
+
+  @Test func `should stream a file body on upload`() async throws {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [RecordingURLProtocol.self]
+    let session = URLSession(configuration: configuration)
+    let networkController = NetworkController(
+      urlSession: session,
+      baseURL: URL(string: "https://example.test/")!
+    )
+
+    let bytes = Data([0x01, 0x02, 0x03])
+    let fileURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent("qualtive-network-\(UUID().uuidString).bin")
+    try bytes.write(to: fileURL)
+    defer { try? FileManager.default.removeItem(at: fileURL) }
+
+    RecordingURLProtocol.handler = { request in
+      #expect(request.url?.absoluteString == "https://uploads.example/put")
+      #expect(request.httpMethod == "PUT")
+      #expect(request.value(forHTTPHeaderField: "Content-Type") == "video/mp4")
+      let response = HTTPURLResponse(
+        url: request.url!,
+        statusCode: 200,
+        httpVersion: nil,
+        headerFields: nil
+      )!
+      return (Data(), response)
+    }
+    defer { RecordingURLProtocol.handler = nil }
+
+    let (_, response) = try await networkController.send(
+      method: "PUT",
+      url: URL(string: "https://uploads.example/put")!,
+      headers: ["Content-Type": "video/mp4"],
+      fileURL: fileURL
+    )
+    #expect(response.statusCode == 200)
+  }
 }
 
 private final class RecordingURLProtocol: URLProtocol, @unchecked Sendable {
@@ -198,6 +236,10 @@ private final class RecordingURLProtocol: URLProtocol, @unchecked Sendable {
   nonisolated(unsafe) static var handler: ((URLRequest) throws -> (Data, HTTPURLResponse))?
 
   override class func canInit(with request: URLRequest) -> Bool {
+    true
+  }
+
+  override class func canInit(with task: URLSessionTask) -> Bool {
     true
   }
 

--- a/Tests/QualtiveTests/Controllers/NetworkControllerTests.swift
+++ b/Tests/QualtiveTests/Controllers/NetworkControllerTests.swift
@@ -192,43 +192,48 @@ struct NetworkControllerTests {
     #expect(result.id == 1)
   }
 
-  @Test func `should stream a file body on upload`() async throws {
-    let configuration = URLSessionConfiguration.ephemeral
-    configuration.protocolClasses = [RecordingURLProtocol.self]
-    let session = URLSession(configuration: configuration)
-    let networkController = NetworkController(
-      urlSession: session,
-      baseURL: URL(string: "https://example.test/")!
-    )
+  // watchOS URLSession upload tasks do not consult `URLProtocol`, so this
+  // interceptor-based test cannot run there. File uploads are still covered by
+  // `AttachmentControllerTests`.
+  #if !os(watchOS)
+    @Test func `should stream a file body on upload`() async throws {
+      let configuration = URLSessionConfiguration.ephemeral
+      configuration.protocolClasses = [RecordingURLProtocol.self]
+      let session = URLSession(configuration: configuration)
+      let networkController = NetworkController(
+        urlSession: session,
+        baseURL: URL(string: "https://example.test/")!
+      )
 
-    let bytes = Data([0x01, 0x02, 0x03])
-    let fileURL = FileManager.default.temporaryDirectory
-      .appendingPathComponent("qualtive-network-\(UUID().uuidString).bin")
-    try bytes.write(to: fileURL)
-    defer { try? FileManager.default.removeItem(at: fileURL) }
+      let bytes = Data([0x01, 0x02, 0x03])
+      let fileURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("qualtive-network-\(UUID().uuidString).bin")
+      try bytes.write(to: fileURL)
+      defer { try? FileManager.default.removeItem(at: fileURL) }
 
-    RecordingURLProtocol.handler = { request in
-      #expect(request.url?.absoluteString == "https://uploads.example/put")
-      #expect(request.httpMethod == "PUT")
-      #expect(request.value(forHTTPHeaderField: "Content-Type") == "video/mp4")
-      let response = HTTPURLResponse(
-        url: request.url!,
-        statusCode: 200,
-        httpVersion: nil,
-        headerFields: nil
-      )!
-      return (Data(), response)
+      RecordingURLProtocol.handler = { request in
+        #expect(request.url?.absoluteString == "https://uploads.example/put")
+        #expect(request.httpMethod == "PUT")
+        #expect(request.value(forHTTPHeaderField: "Content-Type") == "video/mp4")
+        let response = HTTPURLResponse(
+          url: request.url!,
+          statusCode: 200,
+          httpVersion: nil,
+          headerFields: nil
+        )!
+        return (Data(), response)
+      }
+      defer { RecordingURLProtocol.handler = nil }
+
+      let (_, response) = try await networkController.send(
+        method: "PUT",
+        url: URL(string: "https://uploads.example/put")!,
+        headers: ["Content-Type": "video/mp4"],
+        fileURL: fileURL
+      )
+      #expect(response.statusCode == 200)
     }
-    defer { RecordingURLProtocol.handler = nil }
-
-    let (_, response) = try await networkController.send(
-      method: "PUT",
-      url: URL(string: "https://uploads.example/put")!,
-      headers: ["Content-Type": "video/mp4"],
-      fileURL: fileURL
-    )
-    #expect(response.statusCode == 200)
-  }
+  #endif
 }
 
 private final class RecordingURLProtocol: URLProtocol, @unchecked Sendable {

--- a/Tests/QualtiveTests/Controllers/PostControllerTests.swift
+++ b/Tests/QualtiveTests/Controllers/PostControllerTests.swift
@@ -70,6 +70,80 @@ struct PostControllerTests {
     #expect(entry.id == 5)
   }
 
+  @Test func `should post attribute-targeted text as attributes`() async throws {
+    let mock = MockNetworkController()
+    mock.pathHandler = { _, _, _, _, body in
+      let posted = decodeJSON(PostedEntryBody.self, from: body!)
+      #expect(posted.content.count == 2)
+      #expect(posted.content[0].type == "score")
+      #expect(posted.content[1].type == "text")
+      #expect(posted.content[1].stringValue == "Hello")
+      #expect(posted.attributes["Age"] == "32")
+      #expect(posted.attributes["Skip"] == nil)
+      return (jsonData(EntryIDResponse(id: 1)), makeHTTPURLResponse(statusCode: 200))
+    }
+
+    var age = Entry.TextContent(
+      enquiryContent: .init(storageTarget: .attribute("Age"))
+    )
+    age.value = "32"
+    var skipped = Entry.TextContent(
+      enquiryContent: .init(storageTarget: .attribute("Skip"))
+    )
+    skipped.value = "   "
+    var note = Entry.TextContent(
+      enquiryContent: .init(storageTarget: .text)
+    )
+    note.value = "Hello"
+
+    let postController = PostController(
+      networkController: mock,
+      standardAttributesController: MockStandardAttributesController(attributes: [:]),
+      userClientIDController: MockUserClientIDController(clientId: "cid")
+    )
+    _ = try await postController.post(
+      to: "ci-test/swift",
+      content: [
+        .score(.init(value: 75)),
+        .text(age),
+        .text(skipped),
+        .text(note),
+      ],
+      customAttributes: ["Age": "99"]
+    )
+  }
+
+  @Test func `should omit device attributes and client id when options deny them`() async throws {
+    let mock = MockNetworkController()
+    mock.pathHandler = { _, _, _, _, body in
+      let posted = decodeJSON(PostedEntryBody.self, from: body!)
+      #expect(posted.attributes["Platform"] == nil)
+      #expect(posted.attributes["Age"] == "32")
+      #expect(posted.user.clientId == nil)
+      return (jsonData(EntryIDResponse(id: 2)), makeHTTPURLResponse(statusCode: 200))
+    }
+
+    let attributes = TrackingStandardAttributesController(attributes: [.platform: "TestOS"])
+    let clientId = TrackingUserClientIDController(clientId: "should-not-be-used")
+    let postController = PostController(
+      networkController: mock,
+      standardAttributesController: attributes,
+      userClientIDController: clientId
+    )
+    _ = try await postController.post(
+      to: "ci-test/swift",
+      content: [.text(.init(value: "Hello"))],
+      customAttributes: ["Age": "32"],
+      options: PostOptions(
+        metadataCollection: .none,
+        userTrackingConsent: .denied
+      )
+    )
+
+    #expect(attributes.makeAttributesCallCount == 0)
+    #expect(clientId.clientIdCallCount == 0)
+  }
+
   @Test func `should throw when enquiry is not found`() async {
     let mock = MockNetworkController()
     mock.pathHandler = { _, _, _, _, _ in
@@ -123,7 +197,7 @@ private struct PostedEntryBody: Decodable {
   let user: UserBody
 
   struct UserBody: Decodable {
-    let clientId: String
+    let clientId: String?
     let id: String?
     let name: String?
     let email: String?
@@ -178,5 +252,38 @@ private struct MockUserClientIDController: UserClientIDControllerType {
 
   func clientId() -> String {
     id
+  }
+}
+
+private final class TrackingStandardAttributesController: StandardAttributesControllerType,
+  @unchecked Sendable
+{
+
+  let attributes: Attributes
+  private(set) var makeAttributesCallCount = 0
+
+  init(attributes: Attributes) {
+    self.attributes = attributes
+  }
+
+  func makeAttributes(locale: Locale) async -> Attributes {
+    makeAttributesCallCount += 1
+    return attributes
+  }
+}
+
+private final class TrackingUserClientIDController: UserClientIDControllerType, @unchecked Sendable
+{
+
+  let id: String
+  private(set) var clientIdCallCount = 0
+
+  init(clientId: String) {
+    self.id = clientId
+  }
+
+  func clientId() -> String {
+    clientIdCallCount += 1
+    return id
   }
 }


### PR DESCRIPTION
## Summary
- Honor `storageTarget` on post so attribute-targeted text is sent as attributes, not text content.
- Add per-post `PostOptions` for metadata collection and user tracking consent.
- Allow any MIME type and streamed file-URL attachment uploads; hide helper controllers from the public API.

## Test plan
- [ ] `swift test` (unit + integration)
- [ ] Post an enquiry field stored as an attribute and confirm it does not appear in `content`
- [ ] Post with `PostOptions(metadataCollection: .none, userTrackingConsent: .denied)` and confirm no device attributes or client id
- [ ] Upload a PNG via `.data` and a file via `.file`